### PR TITLE
Add Transaction Envelope

### DIFF
--- a/src/main/kotlin/org/onflow/sdk/models.kt
+++ b/src/main/kotlin/org/onflow/sdk/models.kt
@@ -314,7 +314,10 @@ internal class Payload(
     val proposalKeySequenceNumber: Long,
     val payer: ByteArray,
     val authorizers: List<ByteArray>
-)
+) {
+    // no-arg constructor required for decoding
+    constructor() : this(byteArrayOf(), listOf(), byteArrayOf(), 0, byteArrayOf(), 0, 0, byteArrayOf(), listOf())
+}
 
 internal class PayloadEnvelope(
     @RLP(0) val payload: Payload,
@@ -326,11 +329,20 @@ internal class PaymentEnvelope(
     @RLP(1) val envelopeSignatures: List<EnvelopeSignature>
 )
 
+internal class TransactionEnvelope(
+    @RLP(0) val payload: Payload = Payload(),
+    @RLP(1) val payloadSignatures: List<EnvelopeSignature> = emptyList(),
+    @RLP(2) val envelopeSignatures: List<EnvelopeSignature> = emptyList()
+)
+
 internal class EnvelopeSignature(
     val signerIndex: Int,
     val keyIndex: Int,
     val signature: ByteArray
-)
+) {
+    // no-arg constructor required for decoding
+    constructor() : this(0, 0, byteArrayOf())
+}
 
 data class FlowTransaction(
     val script: FlowScript,
@@ -350,7 +362,7 @@ data class FlowTransaction(
         referenceBlockId = referenceBlockId.bytes,
         gasLimit = gasLimit,
         proposalKeyAddress = proposalKey.address.bytes,
-        proposalKeyIndex = proposalKey.keyIndex.toLong(), // TODO: type missmatch here
+        proposalKeyIndex = proposalKey.keyIndex.toLong(), // TODO: type mismatch here
         proposalKeySequenceNumber = proposalKey.sequenceNumber,
         payer = payerAddress.bytes,
         authorizers = authorizers.map { it.bytes }
@@ -378,9 +390,29 @@ data class FlowTransaction(
         }
     )
 
+    private val transaction: TransactionEnvelope get() = TransactionEnvelope(
+        payload = payload,
+        payloadSignatures = payloadSignatures.map {
+            EnvelopeSignature(
+                signerIndex = it.signerIndex,
+                keyIndex = it.keyIndex,
+                signature = it.signature.bytes
+            )
+        },
+        envelopeSignatures = envelopeSignatures.map {
+            EnvelopeSignature(
+                signerIndex = it.signerIndex,
+                keyIndex = it.keyIndex,
+                signature = it.signature.bytes
+            )
+        }
+    )
+
     val canonicalPayload: ByteArray get() = RLPCodec.encode(payload)
     val canonicalAuthorizationEnvelope: ByteArray get() = RLPCodec.encode(authorization)
     val canonicalPaymentEnvelope: ByteArray get() = RLPCodec.encode(payment)
+    val canonicalTransaction: ByteArray get() = RLPCodec.encode(transaction)
+    val id: FlowId get() = FlowId.of(canonicalTransaction.sha3256Hash())
 
     val signerList: List<FlowAddress> get() {
         val ret = mutableListOf<FlowAddress>()
@@ -417,6 +449,32 @@ data class FlowTransaction(
             payloadSignatures = value.payloadSignaturesList.map { FlowTransactionSignature.of(it) },
             envelopeSignatures = value.envelopeSignaturesList.map { FlowTransactionSignature.of(it) }
         )
+
+        @JvmStatic
+        fun of(bytes: ByteArray): FlowTransaction {
+            val txEnvelope: TransactionEnvelope = RLPCodec.decode(bytes, TransactionEnvelope::class.java)
+            var tx = FlowTransaction(
+                script = FlowScript(txEnvelope.payload.script),
+                arguments = txEnvelope.payload.arguments.map { FlowArgument(it) },
+                referenceBlockId = FlowId.of(txEnvelope.payload.referenceBlockId),
+                gasLimit = txEnvelope.payload.gasLimit,
+                proposalKey = FlowTransactionProposalKey(
+                    FlowAddress.of(txEnvelope.payload.proposalKeyAddress),
+                    txEnvelope.payload.proposalKeyIndex.toInt(),
+                    txEnvelope.payload.proposalKeySequenceNumber
+                ),
+                payerAddress = FlowAddress.of(txEnvelope.payload.payer),
+                authorizers = txEnvelope.payload.authorizers.map { FlowAddress.of(it) }
+            )
+
+            txEnvelope.payloadSignatures.map {
+                tx = tx.addPayloadSignature(tx.signerList[it.signerIndex], it.keyIndex, FlowSignature(it.signature))
+            }
+            txEnvelope.envelopeSignatures.map {
+                tx = tx.addEnvelopeSignature(tx.signerList[it.signerIndex], it.keyIndex, FlowSignature(it.signature))
+            }
+            return tx
+        }
     }
 
     @JvmOverloads

--- a/src/test/kotlin/org/onflow/sdk/TransactionTest.kt
+++ b/src/test/kotlin/org/onflow/sdk/TransactionTest.kt
@@ -269,4 +269,73 @@ class TransactionTest {
         assertThat(account.address).isEqualTo(address)
         assertThat(account).isEqualTo(account)
     }
+
+    @Test
+    fun `Can decode transaction envelope`() {
+        // the value below was calculated using the flow-go-sdk from the tx defined here https://github.com/onflow/flow-go-sdk/blob/3ecd5d4920939922bb3b010b0d1b5567131b1341/transaction_test.go#L119-L129
+        val canonicalTransactionHex = "f882f872b07472616e73616374696f6e207b2065786563757465207b206c6f67282248656c6c6f2c20576f726c64212229207d207dc0a001020000000000000000000000000000000000000000000000000000000000002a88f8d6e0586b0a20c7032a88ee82856bf20e2aa6c988f8d6e0586b0a20c7c8c3800202c3800301c4c3010703"
+        val expectedTransactionId = "d1a2c58aebfce1050a32edf3568ec3b69cb8637ae090b5f7444ca6b2a8de8f8b"
+        val proposerAddress = "f8d6e0586b0a20c7"
+        val payerAddress = "ee82856bf20e2aa6"
+
+        val decodedTx = FlowTransaction.of(canonicalTransactionHex.hexToBytes())
+
+        assertThat(decodedTx.script).isEqualTo(FlowScript("transaction { execute { log(\"Hello, World!\") } }"))
+        assertThat(decodedTx.arguments).isEqualTo(emptyList<FlowArgument>())
+        assertThat(decodedTx.referenceBlockId).isEqualTo(FlowId.of(byteArrayOf(1, 2).copyOf(32)))
+        assertThat(decodedTx.gasLimit).isEqualTo(42)
+        assertThat(decodedTx.proposalKey.address.base16Value).isEqualTo(proposerAddress)
+        assertThat(decodedTx.proposalKey.keyIndex).isEqualTo(3)
+        assertThat(decodedTx.proposalKey.sequenceNumber).isEqualTo(42)
+        assertThat(decodedTx.payerAddress.base16Value).isEqualTo(payerAddress)
+        assertThat(decodedTx.authorizers).isEqualTo(listOf(FlowAddress(proposerAddress)))
+
+        assertThat(decodedTx.payloadSignatures).isEqualTo(
+            listOf(
+                FlowTransactionSignature(FlowAddress("f8d6e0586b0a20c7"), 0, 2, FlowSignature(byteArrayOf(2))),
+                FlowTransactionSignature(
+                    FlowAddress("f8d6e0586b0a20c7"), 0, 3, FlowSignature(byteArrayOf(1))
+                )
+            )
+        )
+        assertThat(decodedTx.envelopeSignatures).isEqualTo(
+            listOf(FlowTransactionSignature(FlowAddress(payerAddress), 1, 7, FlowSignature(byteArrayOf(3))))
+        )
+
+        assertThat(decodedTx.id.base16Value).isEqualTo(expectedTransactionId)
+        assertThat(decodedTx.canonicalTransaction.bytesToHex()).isEqualTo(canonicalTransactionHex)
+    }
+
+    @Test
+    fun `Can precompute the transaction id`() {
+        // the example below was retrieved from https://github.com/onflow/flow-go-sdk/blob/3ecd5d4920939922bb3b010b0d1b5567131b1341/transaction_test.go#L119-L129
+        val expectedTransactionIdBeforeSigning = "8c362dd8b7553d48284cecc94d2ab545d513b29f930555632390fff5ca9772ee"
+        val expectedTransactionIdAfterSigning = "d1a2c58aebfce1050a32edf3568ec3b69cb8637ae090b5f7444ca6b2a8de8f8b"
+        val expectedCanonicalTransactionHex = "f882f872b07472616e73616374696f6e207b2065786563757465207b206c6f67282248656c6c6f2c20576f726c64212229207d207dc0a001020000000000000000000000000000000000000000000000000000000000002a88f8d6e0586b0a20c7032a88ee82856bf20e2aa6c988f8d6e0586b0a20c7c8c3800202c3800301c4c3010703"
+        val proposerAddress = "f8d6e0586b0a20c7"
+        val payerAddress = "ee82856bf20e2aa6"
+
+        var testTx = FlowTransaction(
+            script = FlowScript("transaction { execute { log(\"Hello, World!\") } }"),
+            arguments = emptyList(),
+            referenceBlockId = FlowId.of(byteArrayOf(1, 2).copyOf(32)),
+            gasLimit = 42,
+            proposalKey = FlowTransactionProposalKey(
+                address = FlowAddress(proposerAddress),
+                keyIndex = 3,
+                sequenceNumber = 42
+            ),
+            payerAddress = FlowAddress(payerAddress),
+            authorizers = listOf(FlowAddress(proposerAddress))
+        )
+
+        assertThat(testTx.id.base16Value).isEqualTo(expectedTransactionIdBeforeSigning)
+
+        testTx = testTx.addPayloadSignature(FlowAddress(proposerAddress), 3, FlowSignature(byteArrayOf(1)))
+        testTx = testTx.addPayloadSignature(FlowAddress(proposerAddress), 2, FlowSignature(byteArrayOf(2)))
+        testTx = testTx.addEnvelopeSignature(FlowAddress(payerAddress), 7, FlowSignature(byteArrayOf(3)))
+
+        assertThat(testTx.id.base16Value).isEqualTo(expectedTransactionIdAfterSigning)
+        assertThat(testTx.canonicalTransaction.bytesToHex()).isEqualTo(expectedCanonicalTransactionHex)
+    }
 }


### PR DESCRIPTION
## Description
This PR adds support for the following functionality:
- Retrieve the canonical transaction bytes from the `FlowTransaction`
- Pre-compute the transaction id from the canonical transaction bytes
- Decode the `FlowTransaction` from the canonical transaction bytes 

Spec:

1. Add a new class `TransactionEnvelope` to represent the canonical transaction message
2. Add a new property `val id: FlowId` to the `FlowTransaction` class
3. Add a new static method `FlowTransaction.of(bytes: ByteArray): FlowTransaction` to decode the canonical bytes

Why this is useful:

- Enables pre-computing the TransactionId before sending the transaction to the network
- Enables retrieving the raw canonical transaction bytes
- Feature-parity with [flow-go-sdk](https://github.com/onflow/flow-go-sdk/blob/3ecd5d4920939922bb3b010b0d1b5567131b1341/transaction.go#L107) `Encode()`, `Decode()` and `ID` methods

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work. (Described above)
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
