### PR TITLE
Unit tests: Field, AddressField, VoidField

### DIFF
--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderAddressFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderAddressFieldTest.kt
@@ -1,0 +1,51 @@
+package com.nftco.flow.sdk.cadence.fields
+
+import com.nftco.flow.sdk.cadence.AddressField
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class JsonCadenceBuilderAddressFieldTest {
+
+    @Test
+    fun `Test equality for AddressField with the same value`() {
+        val address1 = AddressField("0x123")
+        val address2 = AddressField("0x123")
+        assertEquals(address1, address2)
+        assertEquals(address1.hashCode(), address2.hashCode())
+    }
+
+    @Test
+    fun `Test equality for AddressField with different values`() {
+        val address1 = AddressField("0x123")
+        val address2 = AddressField("0x456")
+        assertNotEquals(address1, address2)
+        assertNotEquals(address1.hashCode(), address2.hashCode())
+    }
+
+    @Test
+    fun `Test equality for AddressField with lowercase value`() { // need to investigate this case
+        val address1 = AddressField("0xABC")
+        val address2 = AddressField("0xabc")
+        assertEquals(address1, address2)
+        assertEquals(address1.hashCode(), address2.hashCode())
+    }
+
+    @Test
+    fun `Test equality for AddressField with bytes`() {
+        val bytes = byteArrayOf(1, 2, 3)
+        val address1 = AddressField(bytes)
+        val address2 = AddressField("0x010203")
+        assertEquals(address1, address2)
+        assertEquals(address1.hashCode(), address2.hashCode())
+    }
+
+    @Test
+    fun `Test equality for AddressField with bytes and different values`() {
+        val bytes = byteArrayOf(1, 2, 3)
+        val address1 = AddressField(bytes)
+        val address2 = AddressField("0x040506")
+        assertNotEquals(address1, address2)
+        assertNotEquals(address1.hashCode(), address2.hashCode())
+    }
+}

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderAddressFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderAddressFieldTest.kt
@@ -22,7 +22,7 @@ class JsonCadenceBuilderAddressFieldTest {
         val addressValue = "0x0f7531409b1719ee"
         val addressField = AddressField(addressValue)
 
-        val result =  addressField.decodeToAny()
+        val result = addressField.decodeToAny()
         val expectedBytes = "15, 117, 49, 64, -101, 23, 25, -18".split(", ").map { it.toByte() }.toByteArray()
 
         assertThat(result).isInstanceOf(FlowAddress::class.java)

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderAddressFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderAddressFieldTest.kt
@@ -1,11 +1,41 @@
 package com.nftco.flow.sdk.cadence.fields
 
+import com.nftco.flow.sdk.FlowAddress
 import com.nftco.flow.sdk.cadence.AddressField
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class JsonCadenceBuilderAddressFieldTest {
+
+    @Test
+    fun `test decoding AddressField with decodeToAny`() {
+        val addressValue = "0x0f7531409b1719ee"
+        val addressField = AddressField(addressValue)
+
+        assertDoesNotThrow { addressField.decodeToAny() }
+    }
+
+    @Test
+    fun `test decoding AddressField to FlowAddress`() {
+        val addressValue = "0x0f7531409b1719ee"
+        val addressField = AddressField(addressValue)
+
+        val result =  addressField.decodeToAny()
+        val expectedBytes = "15, 117, 49, 64, -101, 23, 25, -18".split(", ").map { it.toByte() }.toByteArray()
+
+        assertThat(result).isInstanceOf(FlowAddress::class.java)
+        assertThat((result as FlowAddress).bytes).isEqualTo(expectedBytes)
+    }
+
+    @Test
+    fun `test decoding invalid AddressField with decodeToAny`() {
+        val invalidAddressValue = "invalid_address"
+        val addressField = AddressField(invalidAddressValue)
+
+        assertThrows<Exception> { addressField.decodeToAny() }
+    }
 
     @Test
     fun `Test equality for AddressField with the same value`() {

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderFieldTest.kt
@@ -1,13 +1,14 @@
 package com.nftco.flow.sdk.cadence.fields
 
-import com.nftco.flow.sdk.cadence.Field
-import com.nftco.flow.sdk.cadence.TYPE_INT
-import com.nftco.flow.sdk.cadence.TYPE_STRING
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nftco.flow.sdk.cadence.*
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 class JsonCadenceBuilderFieldTest {
+
+    private val objectMapper = ObjectMapper()
     @Test
     fun `Test equality for Field with the same type and value`() {
         val field1 = SampleField(TYPE_STRING, "value")
@@ -56,5 +57,14 @@ class JsonCadenceBuilderFieldTest {
         assertFalse(field1.hashCode() == field2.hashCode())
     }
 
+    @Test
+    fun `Test decoding unsupported field throws exception`() {
+        val unsupportedField = object : Field<Unit>("Unsupported", null) {}
+        val expectedMessage = " Can't find right class "
+
+        assertThatThrownBy { unsupportedField.decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+            .hasMessage(expectedMessage)
+    }
     private class SampleField(type: String, value: Any?) : Field<Any>(type, value)
 }

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderFieldTest.kt
@@ -1,0 +1,60 @@
+package com.nftco.flow.sdk.cadence.fields
+
+import com.nftco.flow.sdk.cadence.Field
+import com.nftco.flow.sdk.cadence.TYPE_INT
+import com.nftco.flow.sdk.cadence.TYPE_STRING
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class JsonCadenceBuilderFieldTest {
+    @Test
+    fun `Test equality for Field with the same type and value`() {
+        val field1 = SampleField(TYPE_STRING, "value")
+        val field2 = SampleField(TYPE_STRING, "value")
+        assertTrue(field1 == field2)
+        assertTrue(field1.hashCode() == field2.hashCode())
+    }
+
+    @Test
+    fun `Test equality for Field with different values`() {
+        val field1 = SampleField(TYPE_STRING, "value1")
+        val field2 = SampleField(TYPE_STRING, "value2")
+        assertFalse(field1 == field2)
+        assertFalse(field1.hashCode() == field2.hashCode())
+    }
+
+    @Test
+    fun `Test equality for Field with different types`() {
+        val field1 = SampleField(TYPE_STRING, "value")
+        val field2 = SampleField(TYPE_INT, 42)
+        assertFalse(field1 == field2)
+        assertFalse(field1.hashCode() == field2.hashCode())
+    }
+
+    @Test
+    fun `Test equality for Field with null values`() {
+        val field1 = SampleField(TYPE_STRING, null)
+        val field2 = SampleField(TYPE_STRING, null)
+        assertTrue(field1 == field2)
+        assertTrue(field1.hashCode() == field2.hashCode())
+    }
+
+    @Test
+    fun `Test equality for Field with null value and non-null value`() {
+        val field1 = SampleField(TYPE_STRING, null)
+        val field2 = SampleField(TYPE_STRING, "value")
+        assertFalse(field1 == field2)
+        assertFalse(field1.hashCode() == field2.hashCode())
+    }
+
+    @Test
+    fun `Test equality for Field with different types and values`() {
+        val field1 = SampleField(TYPE_STRING, "value")
+        val field2 = SampleField(TYPE_INT, 42)
+        assertFalse(field1 == field2)
+        assertFalse(field1.hashCode() == field2.hashCode())
+    }
+
+    private class SampleField(type: String, value: Any?) : Field<Any>(type, value)
+}

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderVoidFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderVoidFieldTest.kt
@@ -1,0 +1,33 @@
+package com.nftco.flow.sdk.cadence.fields
+
+import com.nftco.flow.sdk.cadence.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class JsonCadenceBuilderVoidFieldTest {
+
+    @Test
+    fun `Test equality of VoidField instances`() {
+        val voidField1 = VoidField()
+        val voidField2 = VoidField()
+
+        assertEquals(voidField1, voidField2)
+    }
+
+    @Test
+    fun `Test hashing of VoidField instances`() {
+        val voidField1 = VoidField()
+        val voidField2 = VoidField()
+
+        assertEquals(voidField1.hashCode(), voidField2.hashCode())
+    }
+
+    @Test
+    fun `Test equality with other Field types`() {
+        val voidField = VoidField()
+        val stringField = StringField("test")
+
+        assertNotEquals(voidField, stringField)
+    }
+}

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderVoidFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderVoidFieldTest.kt
@@ -1,8 +1,8 @@
 package com.nftco.flow.sdk.cadence.fields
 
 import com.nftco.flow.sdk.cadence.*
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 class JsonCadenceBuilderVoidFieldTest {
@@ -29,5 +29,14 @@ class JsonCadenceBuilderVoidFieldTest {
         val stringField = StringField("test")
 
         assertNotEquals(voidField, stringField)
+    }
+
+    @Test
+    fun `Test decoding VoidField returns null`() {
+        val voidField = VoidField()
+
+        val decodedValue: Any? = voidField.decodeToAny()
+
+        assertThat(decodedValue).isNull()
     }
 }


### PR DESCRIPTION
## Description

Unit tests for: 

com.nftco.flow.sdk.cadence.Field;
com.nftco.flow.sdk.cadence.AddressField;
com.nftco.flow.sdk.cadence.VoidField;

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
