### PR TITLE
Unit tests: BooleanField, ArrayField

### DIFF
--- a/src/main/kotlin/com/nftco/flow/sdk/cadence/json-cadence.kt
+++ b/src/main/kotlin/com/nftco/flow/sdk/cadence/json-cadence.kt
@@ -307,6 +307,17 @@ open class UFix64NumberField(value: String) : NumberField(TYPE_UFIX64, value)
 
 open class ArrayField(value: Array<Field<*>>) : Field<Array<Field<*>>>(TYPE_ARRAY, value) {
     constructor(value: Iterable<Field<*>>) : this(value.toList().toTypedArray())
+
+    override fun hashCode(): Int {
+        return value?.contentHashCode() ?: 0
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+        return true
+    }
 }
 
 open class DictionaryField(value: Array<DictionaryFieldEntry>) : Field<Array<DictionaryFieldEntry>>(TYPE_DICTIONARY, value) {

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderArrayFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderArrayFieldTest.kt
@@ -1,0 +1,75 @@
+package com.nftco.flow.sdk.cadence.fields
+
+import com.nftco.flow.sdk.cadence.ArrayField
+import com.nftco.flow.sdk.cadence.Field
+import com.nftco.flow.sdk.cadence.IntNumberField
+import com.nftco.flow.sdk.cadence.StringField
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class JsonCadenceBuilderArrayFieldTest {
+
+    @Test
+    fun `Test equality for ArrayField`() {
+        val array1 = ArrayField(arrayOf(StringField("abc"), IntNumberField("42")))
+        val array2 = ArrayField(arrayOf(StringField("abc"), IntNumberField("42")))
+
+        assertEquals(array1, array2)
+        assertEquals(array1.hashCode(), array2.hashCode())
+    }
+
+    @Test
+    fun `Test inequality for different ArrayField values`() {
+        val array1 = ArrayField(arrayOf(StringField("abc"), IntNumberField("42")))
+        val array2 = ArrayField(arrayOf(StringField("def"), IntNumberField("42")))
+
+        assertNotEquals(array1, array2)
+    }
+
+    @Test
+    fun `Test decoding of ArrayField`() {
+        val arrayField = ArrayField(arrayOf(StringField("abc"), IntNumberField("42")))
+        val decodedArray = arrayField.decodeToAny()
+
+        assertEquals(listOf("abc", 42), decodedArray)
+    }
+
+    @Test
+    fun `Test decoding of empty ArrayField`() {
+        val emptyArrayField = ArrayField(emptyArray())
+        val decodedArray = emptyArrayField.decodeToAny()
+
+        assertEquals(emptyList<Any>(), decodedArray)
+    }
+
+    @Test
+    fun `Test hash code for ArrayField`() {
+        val array1 = ArrayField(arrayOf(StringField("abc"), IntNumberField("42")))
+        val array2 = ArrayField(arrayOf(StringField("abc"), IntNumberField("42")))
+
+        assertEquals(array1.hashCode(), array2.hashCode())
+    }
+
+    @Test
+    fun `Test hash code for different ArrayField values`() {
+        val array1 = ArrayField(arrayOf(StringField("abc"), IntNumberField("42")))
+        val array2 = ArrayField(arrayOf(StringField("def"), IntNumberField("42")))
+
+        assertNotEquals(array1.hashCode(), array2.hashCode())
+    }
+
+    @Test
+    fun `Test decoding of ArrayField with an element of unsupported type`() {
+        val arrayField = ArrayField(arrayOf(StringField("abc"), UnsupportedField()))
+
+        val expectedMessage = " Can't find right class "
+
+        assertThatThrownBy { arrayField.decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+            .hasMessage(expectedMessage)
+    }
+
+    private class UnsupportedField : Field<String>("UnsupportedType", "value")
+}

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderBooleanFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderBooleanFieldTest.kt
@@ -1,0 +1,58 @@
+package com.nftco.flow.sdk.cadence.fields
+
+import com.nftco.flow.sdk.cadence.BooleanField
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class JsonCadenceBuilderBooleanFieldTest {
+
+    @Test
+    fun `Test equality for BooleanField`() {
+        val bool1 = BooleanField(true)
+        val bool2 = BooleanField(true)
+        val bool3 = BooleanField(false)
+
+        assertEquals(bool1, bool2)
+        assertEquals(bool1.hashCode(), bool2.hashCode())
+
+        assertNotEquals(bool1, bool3)
+        assertNotEquals(bool1.hashCode(), bool3.hashCode())
+    }
+
+    @Test
+    fun `Test hashCode for BooleanField with true value`() {
+        val boolField1 = BooleanField(true)
+        val boolField2 = BooleanField(true)
+
+        assertEquals(boolField1.hashCode(), boolField2.hashCode())
+    }
+
+    @Test
+    fun `Test hashCode for BooleanField with false value`() {
+        val boolField1 = BooleanField(false)
+        val boolField2 = BooleanField(false)
+
+        assertEquals(boolField1.hashCode(), boolField2.hashCode())
+    }
+
+    @Test
+    fun `Test hashCode for different BooleanField values`() {
+        val boolField1 = BooleanField(true)
+        val boolField2 = BooleanField(false)
+
+        assert(boolField1.hashCode() != boolField2.hashCode())
+    }
+
+    @Test
+    fun `Test decoding of BooleanField with true value`() {
+        val boolField = BooleanField(true)
+        assertEquals(true, boolField.decodeToAny())
+    }
+
+    @Test
+    fun `Test decoding of BooleanField with false value`() {
+        val boolField = BooleanField(false)
+        assertEquals(false, boolField.decodeToAny())
+    }
+}


### PR DESCRIPTION

## Description

Unit tests for:

com.nftco.flow.sdk.cadence.BooleanField;
com.nftco.flow.sdk.cadence.ArrayField;


- Updated ArrayField hashCode() method for tests to succeed; hash codes returned for Arrays using existing method were not equal.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
