### PR TITLE
Unit tests: number fields

### DIFF
--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderNumberFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderNumberFieldTest.kt
@@ -1,0 +1,203 @@
+package com.nftco.flow.sdk.cadence.fields.number
+
+import com.nftco.flow.sdk.cadence.*
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.BigInteger
+
+class JsonCadenceBuilderNumberFieldTest {
+
+    @Test
+    fun `Test creating NumberField with valid values`() {
+        val intField = NumberField(TYPE_INT, "42")
+        assertEquals("42", intField.value)
+
+        val uintField = NumberField(TYPE_UINT, "42")
+        assertEquals("42", uintField.value)
+
+        val int8Field = NumberField(TYPE_INT8, "42")
+        assertEquals("42", int8Field.value)
+
+        val uint8Field = NumberField(TYPE_UINT8, "42")
+        assertEquals("42", uint8Field.value)
+
+        val int16Field = NumberField(TYPE_INT16, "32767")
+        assertEquals("32767", int16Field.value)
+
+        val uint16Field = NumberField(TYPE_UINT16, "65535")
+        assertEquals("65535", uint16Field.value)
+
+        val int32Field = NumberField(TYPE_INT32, "-2147483648")
+        assertEquals("-2147483648", int32Field.value)
+
+        val uint32Field = NumberField(TYPE_UINT32, "4294967295")
+        assertEquals("4294967295", uint32Field.value)
+
+        val int64Field = NumberField(TYPE_INT64, "-9223372036854775808")
+        assertEquals("-9223372036854775808", int64Field.value)
+
+        val uint64Field = NumberField(TYPE_UINT64, "18446744073709551615")
+        assertEquals("18446744073709551615", uint64Field.value)
+
+        val int256Field = NumberField(
+            TYPE_INT256,
+            "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+        )
+        assertEquals(
+            "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+            int256Field.value
+        )
+
+        val fix64Field = NumberField(TYPE_FIX64, "42.123456789")
+        assertEquals("42.123456789", fix64Field.value)
+
+        val ufix64Field = NumberField(TYPE_UFIX64, "12345678901234567890.123456789012345678")
+        assertEquals("12345678901234567890.123456789012345678", ufix64Field.value)
+    }
+
+    @Test
+    fun `Test converting NumberField to UByte`() {
+        val field = NumberField(TYPE_UINT8, "42")
+        assertEquals(42.toUByte(), field.toUByte())
+    }
+
+    @Test
+    fun `Test converting NumberField to Byte`() {
+        val field = NumberField(TYPE_INT8, "-42")
+        assertEquals((-42).toByte(), field.toByte())
+    }
+
+    @Test
+    fun `Test converting NumberField to UShort`() {
+        val field = NumberField(TYPE_UINT16, "65535")
+        assertEquals(65535.toUShort(), field.toUShort())
+    }
+
+    @Test
+    fun `Test converting NumberField to Short`() {
+        val field = NumberField(TYPE_INT16, "-32768")
+        assertEquals((-32768).toShort(), field.toShort())
+    }
+
+    @Test
+    fun `Test converting NumberField to UInt`() {
+        val field = NumberField(TYPE_UINT32, "4294967295")
+        assertEquals(4294967295u, field.toUInt())
+    }
+
+    @Test
+    fun `Test converting NumberField to Int`() {
+        val field = NumberField(TYPE_INT32, "-2147483648")
+        assertEquals(-2147483648, field.toInt())
+    }
+
+    @Test
+    fun `Test converting NumberField to ULong`() {
+        val field = NumberField(TYPE_UINT64, "18446744073709551615")
+        assertEquals(18446744073709551615u.toULong(), field.toULong())
+    }
+
+    @Test
+    fun `Test converting NumberField to Long`() {
+        val field = NumberField(TYPE_INT64, "-922337203685477580")
+        assertEquals(-922337203685477580, field.toLong())
+    }
+
+    @Test
+    fun `Test converting NumberField to BigInteger`() {
+        val field = NumberField(TYPE_INT256, "12345678901234567890123456789012345678901234567890123456789012345678901234567890")
+        assertEquals(BigInteger("12345678901234567890123456789012345678901234567890123456789012345678901234567890"), field.toBigInteger())
+    }
+
+    @Test
+    fun `Test converting NumberField to Float`() {
+        val field = NumberField(TYPE_FIX64, "42.0")
+        assertEquals(42.0f, field.toFloat())
+    }
+
+    @Test
+    fun `Test converting NumberField to Double`() {
+        val field = NumberField(TYPE_FIX64, "42.123456789")
+        assertEquals(42.123456789, field.toDouble())
+    }
+
+    @Test
+    fun `Test converting NumberField to BigDecimal`() {
+        val field = NumberField(TYPE_UFIX64, "12345678901234567890.123456789012345678")
+        assertEquals(BigDecimal("12345678901234567890.123456789012345678"), field.toBigDecimal())
+    }
+
+    @Test
+    fun `Test creating NumberField with invalid values`() {
+        assertThatThrownBy { NumberField(TYPE_INT, "abc").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_UINT, "-42").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_INT8, "128").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_UINT8, "-1").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_INT16, "32768").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_UINT16, "-1").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_INT32, "2147483648").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_UINT32, "-1").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_INT64, "9223372036854775808").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_UINT64, "-1").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_INT128, "170141183460469231731687303715884105728").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_UINT128, "-1").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_INT256, "115792089237316195423570985008687907853269984665640564039457584007913129639936").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_UINT256, "-1").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_WORD8, "256").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_WORD16, "65536").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_WORD32, "4294967296").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_WORD64, "18446744073709551616").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_FIX64, "3.14").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_UFIX64, "-1.23").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+    }
+
+    @Test
+    fun `Test decoding NumberField with blank or empty value`() {
+        assertThatThrownBy { NumberField(TYPE_UINT, "   ").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+
+        assertThatThrownBy { NumberField(TYPE_INT8, "").decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+    }
+}

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderNumberFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderNumberFieldTest.kt
@@ -8,7 +8,6 @@ import java.math.BigDecimal
 import java.math.BigInteger
 
 class JsonCadenceBuilderNumberFieldTest {
-
     @Test
     fun `Test creating NumberField with valid values`() {
         val intField = NumberField(TYPE_INT, "42")

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUFix64NumberFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUFix64NumberFieldTest.kt
@@ -1,0 +1,50 @@
+package com.nftco.flow.sdk.cadence.fields.number
+
+import com.nftco.flow.sdk.cadence.UFix64NumberField
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class JsonCadenceBuilderUFix64NumberFieldTest {
+
+    @Test
+    fun `Test decoding of UFix64NumberField`() {
+        val ufix64Field = UFix64NumberField("123.456")
+        assertEquals(123.456, ufix64Field.decodeToAny())
+    }
+
+    @Test
+    fun `Test decoding of UFix64NumberField with zero value`() {
+        val ufix64Field = UFix64NumberField("0.0")
+        assertEquals(0.0, ufix64Field.decodeToAny())
+    }
+
+    @Test
+    fun `Test decoding of UFix64NumberField with large value`() {
+        val ufix64Field = UFix64NumberField("9876543210.123456789")
+        assertEquals(9876543210.123456789, ufix64Field.decodeToAny())
+    }
+
+    @Test
+    fun `Test decoding of UFix64NumberField with scientific notation`() {
+        val ufix64Field = UFix64NumberField("1.23e3")
+        assertEquals(1230.0, ufix64Field.decodeToAny())
+    }
+
+    @Test
+    fun `Test hashCode on UFix64NumberField`() {
+        val ufix64Field1 = UFix64NumberField("123")
+        val ufix64Field2 = UFix64NumberField("123")
+
+        assertEquals(ufix64Field1.hashCode(), ufix64Field2.hashCode())
+    }
+
+    @Test
+    fun `Test decoding of UFix64NumberField with invalid value`() {
+        Assertions.assertThatThrownBy { UFix64NumberField("invalidValue").decodeToAny() }
+            .isInstanceOf(NumberFormatException::class.java)
+    }
+}
+
+
+

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUFix64NumberFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUFix64NumberFieldTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class JsonCadenceBuilderUFix64NumberFieldTest {
-
     @Test
     fun `Test decoding of UFix64NumberField`() {
         val ufix64Field = UFix64NumberField("123.456")
@@ -45,6 +44,3 @@ class JsonCadenceBuilderUFix64NumberFieldTest {
             .isInstanceOf(NumberFormatException::class.java)
     }
 }
-
-
-

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUInt64NumberFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUInt64NumberFieldTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class JsonCadenceBuilderUInt64NumberFieldTest {
-
     @Test
     fun `Test decoding of UInt64NumberField with valid value`() {
         val uint64Field = UInt64NumberField("12345678901234567890")

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUInt64NumberFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUInt64NumberFieldTest.kt
@@ -1,0 +1,41 @@
+package com.nftco.flow.sdk.cadence.fields.number
+
+import com.nftco.flow.sdk.cadence.UInt64NumberField
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class JsonCadenceBuilderUInt64NumberFieldTest {
+
+    @Test
+    fun `Test decoding of UInt64NumberField with valid value`() {
+        val uint64Field = UInt64NumberField("12345678901234567890")
+        assertEquals(12345678901234567890UL, uint64Field.decodeToAny())
+    }
+
+    @Test
+    fun `Test decoding of UInt64NumberField with zero value`() {
+        val uint64Field = UInt64NumberField("0")
+        assertEquals(0UL, uint64Field.decodeToAny())
+    }
+
+    @Test
+    fun `Test decoding of UInt64NumberField with maximum value`() {
+        val uint64Field = UInt64NumberField("18446744073709551615")
+        assertEquals(18446744073709551615UL, uint64Field.decodeToAny())
+    }
+
+    @Test
+    fun `Test hashCode on UInt64NumberField`() {
+        val uint64Field1 = UInt64NumberField("123")
+        val uint64Field2 = UInt64NumberField("123")
+
+        assertEquals(uint64Field1.hashCode(), uint64Field2.hashCode())
+    }
+
+    @Test
+    fun `Test decoding of UInt64NumberField with invalid value`() {
+        Assertions.assertThatThrownBy { UInt64NumberField("invalidValue").decodeToAny() }
+            .isInstanceOf(NumberFormatException::class.java)
+    }
+}

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUInt8NumberFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUInt8NumberFieldTest.kt
@@ -1,0 +1,27 @@
+package com.nftco.flow.sdk.cadence.fields.number
+
+import com.nftco.flow.sdk.cadence.UInt8NumberField
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class JsonCadenceBuilderUInt8NumberFieldTest {
+    @Test
+    fun `Test creating UInt8NumberField with valid value`() {
+        val uint8Field = UInt8NumberField("42")
+        assertEquals("42", uint8Field.value)
+    }
+
+    @Test
+    fun `Test hashCode on UInt8NumberField`() {
+        val uint8Field1 = UInt8NumberField("123")
+        val uint8Field2 = UInt8NumberField("123")
+        assertEquals(uint8Field1.hashCode(), uint8Field2.hashCode())
+    }
+
+    @Test
+    fun `Test creating UInt8NumberField with invalid value`() {
+        Assertions.assertThatThrownBy { UInt8NumberField("invalidValue").decodeToAny() }
+            .isInstanceOf(NumberFormatException::class.java)
+    }
+}

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUInt8NumberFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/number/JsonCadenceBuilderUInt8NumberFieldTest.kt
@@ -13,6 +13,12 @@ class JsonCadenceBuilderUInt8NumberFieldTest {
     }
 
     @Test
+    fun `Test decoding of UInt8NumberField with maximum value`() {
+        val uint8Field = UInt8NumberField("255")
+        assertEquals(255U, uint8Field.decodeToAny())
+    }
+
+    @Test
     fun `Test hashCode on UInt8NumberField`() {
         val uint8Field1 = UInt8NumberField("123")
         val uint8Field2 = UInt8NumberField("123")


### PR DESCRIPTION
## Description

Adds unit tests for: 
com.nftco.flow.sdk.cadence.UFix64NumberField;
com.nftco.flow.sdk.cadence.UInt64NumberField;
com.nftco.flow.sdk.cadence.UInt8NumberField;
com.nftco.flow.sdk.cadence.NumberField;

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
