### PR TITLE
Unit tests: optional and string fields

### DIFF
--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderOptionalFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderOptionalFieldTest.kt
@@ -1,0 +1,69 @@
+package com.nftco.flow.sdk.cadence.fields
+
+import com.nftco.flow.sdk.cadence.*
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class JsonCadenceBuilderOptionalFieldTest {
+    @Test
+    fun `Test creating OptionalField with null value`() {
+        val optionalField = OptionalField(null)
+        assertNull(optionalField.value)
+        assertEquals(TYPE_OPTIONAL, optionalField.type)
+    }
+
+    @Test
+    fun `Test creating OptionalField with non-null value`() {
+        val innerField = StringField("Hello, World!")
+        val optionalField = OptionalField(innerField)
+
+        assertEquals(innerField, optionalField.value)
+        assertEquals(TYPE_OPTIONAL, optionalField.type)
+    }
+
+    @Test
+    fun `Test equality of OptionalField`() {
+        val field1 = StringField("Value")
+        val field2 = StringField("Value")
+        val optionalField1 = OptionalField(field1)
+        val optionalField2 = OptionalField(field2)
+        val optionalField3 = OptionalField(null)
+
+        assertTrue(optionalField1 == optionalField2)
+        assertTrue(optionalField1.hashCode() == optionalField2.hashCode())
+
+        assertTrue(optionalField1 != optionalField3)
+        assertTrue(optionalField1.hashCode() != optionalField3.hashCode())
+    }
+
+    @Test
+    fun `Test decoding OptionalField`() {
+        val innerField = StringField("Hello, World!")
+        val optionalField = OptionalField(innerField)
+
+        val decodedValue = optionalField.decodeToAny()
+        assertEquals(innerField.value, decodedValue)
+    }
+
+    @Test
+    fun `Test decoding null OptionalField`() {
+        val optionalField = OptionalField(null)
+
+        val decodedValue = optionalField.decodeToAny()
+        assertNull(decodedValue)
+    }
+
+    @Test
+    fun `Test decoding OptionalField with invalid inner field`() {
+        val invalidInnerField = NumberField(TYPE_INT, "abc")
+        Assertions.assertThatThrownBy { OptionalField(invalidInnerField).decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+    }
+
+    @Test
+    fun `Test decoding OptionalField with invalid null inner field`() {
+        Assertions.assertThatThrownBy { OptionalField(null as Field<*>).decodeToAny() }
+            .isInstanceOf(Exception::class.java)
+    }
+}

--- a/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderStringFieldTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/cadence/fields/JsonCadenceBuilderStringFieldTest.kt
@@ -1,0 +1,53 @@
+package com.nftco.flow.sdk.cadence.fields
+
+import com.nftco.flow.sdk.cadence.StringField
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class JsonCadenceBuilderStringFieldTest {
+    @Test
+    fun `Test creating StringField with valid value`() {
+        val stringValue = "Hello, World!"
+        val stringField = StringField(stringValue)
+        assertEquals(stringValue, stringField.value)
+    }
+
+    @Test
+    fun `Test hashCode`() {
+        val stringValue1 = "Hello, World!"
+        val stringValue2 = "Hello, World!"
+        val stringField1 = StringField(stringValue1)
+        val stringField2 = StringField(stringValue2)
+
+        assertEquals(stringField1.hashCode(), stringField2.hashCode())
+    }
+
+    @Test
+    fun `Test hashCode with different values`() {
+        val stringValue1 = "Hello, World!"
+        val stringValue2 = "Greetings!"
+        val stringField1 = StringField(stringValue1)
+        val stringField2 = StringField(stringValue2)
+
+        assertTrue(stringField1.hashCode() != stringField2.hashCode())
+    }
+
+    @Test
+    fun `Test decoding StringField`() {
+        val stringValue = "Hello, World!"
+        val stringField = StringField(stringValue)
+        val decodedValue = stringField.decodeToAny()
+
+        assertEquals(stringValue, decodedValue)
+    }
+
+    @Test
+    fun `Test decoding empty StringField`() {
+        val stringValue = ""
+        val stringField = StringField(stringValue)
+        val decodedValue = stringField.decodeToAny()
+
+        assertEquals(stringValue, decodedValue)
+    }
+}


### PR DESCRIPTION


## Description

Adds unit tests for: 
com.nftco.flow.sdk.cadence.OptionalField;
com.nftco.flow.sdk.cadence.StringField;

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
