### PR TITLE
Unit tests: DomainTag

### DIFF
--- a/src/test/kotlin/com/nftco/flow/sdk/DomainTagTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/DomainTagTest.kt
@@ -1,0 +1,43 @@
+package com.nftco.flow.sdk
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Test
+
+class DomainTagTest {
+    @Test
+    fun `Test TRANSACTION_DOMAIN_TAG`() {
+        val expected = "FLOW-V0.0-transaction".toByteArray(Charsets.UTF_8)
+        val paddedExpected = expected + ByteArray(32 - expected.size)
+        assertArrayEquals(paddedExpected, DomainTag.TRANSACTION_DOMAIN_TAG)
+    }
+
+    @Test
+    fun `Test USER_DOMAIN_TAG`() {
+        val expected = "FLOW-V0.0-user".toByteArray(Charsets.UTF_8)
+        val paddedExpected = expected + ByteArray(32 - expected.size)
+        assertArrayEquals(paddedExpected, DomainTag.USER_DOMAIN_TAG)
+    }
+
+    @Test
+    fun `Test normalize`() {
+        val input = "test"
+        val expected = "test".toByteArray(Charsets.UTF_8) + ByteArray(28) // Padded to 32 bytes
+        assertArrayEquals(expected, DomainTag.normalize(input))
+    }
+
+    @Test
+    fun `Test normalize with long tag`() {
+        val longTag = "This is a long tag that exceeds 32 characters"
+        assertThatThrownBy { DomainTag.normalize(longTag) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Domain tags cannot be longer than 32 characters")
+    }
+
+    @Test
+    fun `Test normalize with exactly 32 characters`() {
+        val tag = "'Exactly 32 characters long tag'"
+        val expected = tag.toByteArray(Charsets.UTF_8)
+        assertArrayEquals(expected, DomainTag.normalize(tag))
+    }
+}


### PR DESCRIPTION
## Description

Adds unit tests for:
com.nftco.flow.sdk.DomainTag;

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
