### PR TITLE
GH action to publish only

### DIFF
--- a/.github/workflows/ci-manual-publish-snapshot.yml
+++ b/.github/workflows/ci-manual-publish-snapshot.yml
@@ -1,0 +1,65 @@
+name: Manually Publish Snapshot
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    name: Manually publish snapshot
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
+    #services:
+    #  flow-emulator:
+    #    image: gcr.io/flow-container-registry/emulator
+    #    env:
+    #      FLOW_VERBOSE: true
+    #      FLOW_PORT: 3569
+    #      FLOW_INTERVAL: 5s
+    #      FLOW_PERSIST: false
+    #    ports:
+    #      - 3569:3569
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
+
+      - name: Checkout code
+        uses: actions/checkout@v3 
+
+      - name: Setup Java
+        uses: actions/setup-java@v2 
+        with:
+          java-version: '21'
+          java-package: jdk
+          distribution: 'adopt'
+
+      - name: Install flow emulator
+        run: sh -ci "$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)"
+
+      - name: Make gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Build
+        id: build
+        run: ./gradlew --warning-mode all check build -x test -x integrationTest
+
+      - name: Publish snapshot
+        run: |
+          if [[ "${{ secrets.FLOW_JVM_SDK_CICD_PUBLISH_ENABLED }}" != "true" ]];
+          then
+            exit 0;
+          fi
+          ./gradlew \
+            -PsnapshotDate="${{ steps.date.outputs.date }}" \
+            -PgroupId="${{ secrets.FLOW_JVM_SDK_GROUP_ID }}" \
+            -Psigning.key="${{ secrets.FLOW_JVM_SDK_SIGNING_KEY }}" \
+            -Psigning.password="${{ secrets.FLOW_JVM_SDK_SIGNING_PASSWORD }}" \
+            -Psonatype.nexusUrl="${{ secrets.FLOW_JVM_SDK_NEXUS_URL }}" \
+            -Psonatype.snapshotRepositoryUrl="${{ secrets.FLOW_JVM_SDK_SNAPSHOT_REPOSITORY_URL }}" \
+            -Psonatype.username="${{ secrets.FLOW_JVM_SDK_SONATYPE_USERNAME }}" \
+            -Psonatype.password="${{ secrets.FLOW_JVM_SDK_SONATYPE_PASSWORD }}" \
+            -x test \
+            clean \
+            publishToSonatype \
+            closeAndReleaseSonatypeStagingRepository


### PR DESCRIPTION


## Description

For testing release process, create GH action to publish only. Will disable this once we confirm the release to Maven is working 

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
