### PR TITLE
Update GH actions with new release flow

### DIFF
--- a/.github/workflows/ci-manual-publish-release.yml
+++ b/.github/workflows/ci-manual-publish-release.yml
@@ -1,6 +1,6 @@
 name: Manually Publish Release
 on:
-  push:
+  workflow_dispatch:
     branches:
       - main
 jobs:

--- a/.github/workflows/ci-manual-publish-snapshot.yml
+++ b/.github/workflows/ci-manual-publish-snapshot.yml
@@ -1,6 +1,6 @@
 name: Manually Publish Snapshot
 on:
-  push:
+  workflow_dispatch:
     branches:
       - main
 jobs:
@@ -44,7 +44,7 @@ jobs:
         id: build
         run: ./gradlew --warning-mode all check build -x test -x integrationTest
 
-      - name: Publish release
+      - name: Publish snapshot
         env:
           JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
           ORG_GRADLE_PROJECT_mavenCentralUsername:  '${{ secrets.FLOW_JVM_SDK_SONATYPE_USERNAME }}'

--- a/.github/workflows/ci-publish-release.yml
+++ b/.github/workflows/ci-publish-release.yml
@@ -75,22 +75,20 @@ jobs:
           secondary_rate_limit_wait_seconds: 120
 
       - name: Publish release
+        env:
+          JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
+          ORG_GRADLE_PROJECT_mavenCentralUsername: '${{ secrets.FLOW_JVM_SDK_SONATYPE_USERNAME }}'
+          ORG_GRADLE_PROJECT_mavenCentralPassword: '${{ secrets.FLOW_JVM_SDK_SONATYPE_PASSWORD }}'
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.FLOW_JVM_SDK_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.FLOW_JVM_SDK_SIGNING_PASSWORD }}
+
         run: |
           if [[ "${{ secrets.FLOW_JVM_SDK_CICD_PUBLISH_ENABLED }}" != "true" ]];
           then
             exit 0;
           fi
           ./gradlew \
-            -Pversion="${{ steps.get_version.outputs.version-without-v }}" \
-            -PgroupId="${{ secrets.FLOW_JVM_SDK_GROUP_ID }}" \
             -Psigning.key="${{ secrets.FLOW_JVM_SDK_SIGNING_KEY }}" \
             -Psigning.password="${{ secrets.FLOW_JVM_SDK_SIGNING_PASSWORD }}" \
-            -Psonatype.nexusUrl="${{ secrets.FLOW_JVM_SDK_NEXUS_URL }}" \
-            -Psonatype.snapshotRepositoryUrl="${{ secrets.FLOW_JVM_SDK_SNAPSHOT_REPOSITORY_URL }}" \
-            -Psonatype.username="${{ secrets.FLOW_JVM_SDK_SONATYPE_USERNAME }}" \
-            -Psonatype.password="${{ secrets.FLOW_JVM_SDK_SONATYPE_PASSWORD }}" \
-            -x test \
-            clean \
-            publishToSonatype \
-            closeAndReleaseSonatypeStagingRepository
+            publishAndReleaseToMavenCentral --no-configuration-cache
 

--- a/.github/workflows/ci-publish-snapshot.yml
+++ b/.github/workflows/ci-publish-snapshot.yml
@@ -76,21 +76,19 @@ jobs:
           secondary_rate_limit_wait_seconds: 120
 
       - name: Publish snapshot
+        env:
+          JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
+          ORG_GRADLE_PROJECT_mavenCentralUsername: '${{ secrets.FLOW_JVM_SDK_SONATYPE_USERNAME }}'
+          ORG_GRADLE_PROJECT_mavenCentralPassword: '${{ secrets.FLOW_JVM_SDK_SONATYPE_PASSWORD }}'
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.FLOW_JVM_SDK_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.FLOW_JVM_SDK_SIGNING_PASSWORD }}
+
         run: |
           if [[ "${{ secrets.FLOW_JVM_SDK_CICD_PUBLISH_ENABLED }}" != "true" ]];
           then
             exit 0;
           fi
           ./gradlew \
-            -PsnapshotDate="${{ steps.date.outputs.date }}" \
-            -PgroupId="${{ secrets.FLOW_JVM_SDK_GROUP_ID }}" \
             -Psigning.key="${{ secrets.FLOW_JVM_SDK_SIGNING_KEY }}" \
             -Psigning.password="${{ secrets.FLOW_JVM_SDK_SIGNING_PASSWORD }}" \
-            -Psonatype.nexusUrl="${{ secrets.FLOW_JVM_SDK_NEXUS_URL }}" \
-            -Psonatype.snapshotRepositoryUrl="${{ secrets.FLOW_JVM_SDK_SNAPSHOT_REPOSITORY_URL }}" \
-            -Psonatype.username="${{ secrets.FLOW_JVM_SDK_SONATYPE_USERNAME }}" \
-            -Psonatype.password="${{ secrets.FLOW_JVM_SDK_SONATYPE_PASSWORD }}" \
-            -x test \
-            clean \
-            publishToSonatype \
-            closeAndReleaseSonatypeStagingRepository
+            publishToMavenCentral --no-configuration-cache


### PR DESCRIPTION


## Description

- Update GH actions with new release flow
- Update existing immediate publish release/snapshot actions to only run on manual invocation

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
