### PR TITLE
Remove mainnet and testnet access during integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,4 +70,19 @@ subprojects {
             allWarningsAsErrors = false
         }
     }
+
+    tasks.withType<Test> {
+        useJUnitPlatform()
+        testLogging {
+            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+            showExceptions = true
+            showStackTraces = true
+            showCauses = true
+        }
+
+        systemProperty("logback.configurationFile", rootProject.file("./logback.xml").absolutePath)
+        systemProperty("org.slf4j.simpleLogger.defaultLogLevel", "info")
+        systemProperty("io.netty.logger.type", "slf4j")
+        systemProperty("io.netty.leakDetection.level", "DISABLED")
+    }
 }

--- a/logback.xml
+++ b/logback.xml
@@ -7,6 +7,7 @@
     </appender>
 
     <logger name="io.netty" level="info"/>
+    <logger name="io.grpc.netty.shaded.io.netty" level="info"/>
 
     <root level="info">
         <appender-ref ref="STDOUT"/>

--- a/sdk/src/intTest/org/onflow/flow/sdk/IntegrationTestUtils.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/IntegrationTestUtils.kt
@@ -7,7 +7,6 @@ import org.onflow.flow.sdk.crypto.Crypto
 import java.nio.charset.StandardCharsets
 
 object IntegrationTestUtils {
-
     var transaction = FlowTransaction(
         script = FlowScript("import 0xsomething \n {}"),
         arguments = listOf(FlowArgument(byteArrayOf(2, 2, 3)), FlowArgument(byteArrayOf(3, 3, 3))),

--- a/sdk/src/intTest/org/onflow/flow/sdk/IntegrationTestUtils.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/IntegrationTestUtils.kt
@@ -1,6 +1,10 @@
 package org.onflow.flow.sdk
 
+import org.onflow.flow.common.test.FlowTestUtil
+import org.onflow.flow.common.test.TestAccount
 import org.onflow.flow.sdk.cadence.AddressField
+import org.onflow.flow.sdk.crypto.Crypto
+import java.nio.charset.StandardCharsets
 
 object IntegrationTestUtils {
 
@@ -34,5 +38,62 @@ object IntegrationTestUtils {
     fun getAccount(api: FlowAccessApi, address: FlowAddress): FlowAccount {
         val result = api.getAccountAtLatestBlock(address)
         return handleResult(result, "Failed to get account at latest block")
+    }
+
+    fun createAndSubmitAccountCreationTransaction(
+        accessAPI: FlowAccessApi,
+        serviceAccount: TestAccount,
+        scriptPath: String
+    ): FlowTransactionResult {
+        val latestBlockId = getLatestBlockId(accessAPI)
+        val payerAccount = getAccount(accessAPI, serviceAccount.flowAddress)
+
+        val newAccountKeyPair = Crypto.generateKeyPair(SignatureAlgorithm.ECDSA_P256)
+        val newAccountPublicKey = FlowAccountKey(
+            publicKey = FlowPublicKey(newAccountKeyPair.public.hex),
+            signAlgo = SignatureAlgorithm.ECDSA_P256,
+            hashAlgo = HashAlgorithm.SHA3_256,
+            weight = 1000
+        )
+
+        val loadedScript = String(FlowTestUtil.loadScript(scriptPath), StandardCharsets.UTF_8)
+
+        val tx = flowTransaction {
+            script {
+                loadedScript
+            }
+
+            arguments {
+                arg { string(newAccountPublicKey.encoded.bytesToHex()) }
+            }
+
+            referenceBlockId = latestBlockId
+            gasLimit = 100
+
+            proposalKey {
+                address = payerAccount.address
+                keyIndex = payerAccount.keys[0].id
+                sequenceNumber = payerAccount.keys[0].sequenceNumber.toLong()
+            }
+
+            payerAddress = payerAccount.address
+
+            signatures {
+                signature {
+                    address = payerAccount.address
+                    keyIndex = 0
+                    signer = serviceAccount.signer
+                }
+            }
+        }
+
+        val txID = handleResult(accessAPI.sendTransaction(tx), "Failed to send transaction")
+
+        return handleResult(waitForSeal(accessAPI, txID), "Failed to wait for seal")
+    }
+
+    private fun getLatestBlockId(api: FlowAccessApi): FlowId {
+        val result = api.getLatestBlockHeader()
+        return handleResult(result, "Failed to get latest block header").id
     }
 }

--- a/sdk/src/intTest/org/onflow/flow/sdk/IntegrationTestUtils.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/IntegrationTestUtils.kt
@@ -3,12 +3,6 @@ package org.onflow.flow.sdk
 import org.onflow.flow.sdk.cadence.AddressField
 
 object IntegrationTestUtils {
-    fun newMainnetAccessApi(): FlowAccessApi = Flow.newAccessApi(MAINNET_HOSTNAME)
-
-    fun newTestnetAccessApi(): FlowAccessApi = Flow.newAccessApi(TESTNET_HOSTNAME)
-
-    private const val MAINNET_HOSTNAME = "access.mainnet.nodes.onflow.org"
-    private const val TESTNET_HOSTNAME = "access.devnet.nodes.onflow.org"
 
     var transaction = FlowTransaction(
         script = FlowScript("import 0xsomething \n {}"),

--- a/sdk/src/intTest/org/onflow/flow/sdk/cadence/JsonCadenceTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/cadence/JsonCadenceTest.kt
@@ -2,13 +2,19 @@ package org.onflow.flow.sdk.cadence
 
 import kotlinx.serialization.Serializable
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.onflow.flow.common.test.FlowEmulatorTest
+import org.onflow.flow.common.test.FlowTestClient
 import org.onflow.flow.sdk.*
 import java.nio.charset.StandardCharsets
 import org.onflow.flow.common.test.FlowTestUtil
 
+@FlowEmulatorTest
 class JsonCadenceTest {
+
+    @FlowTestClient
+    lateinit var flow: FlowAccessApi
+
     @Serializable
     data class StorageInfo(
         val capacity: Int,
@@ -39,13 +45,6 @@ class JsonCadenceTest {
     data class SomeEnum(
         val rawValue: Int
     )
-
-    private lateinit var flow: FlowAccessApi
-
-    @BeforeEach
-    fun setup() {
-        flow = IntegrationTestUtils.newMainnetAccessApi()
-    }
 
     private fun loadScriptContent(path: String): String {
         return String(FlowTestUtil.loadScript(path), StandardCharsets.UTF_8)

--- a/sdk/src/intTest/org/onflow/flow/sdk/cadence/JsonCadenceTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/cadence/JsonCadenceTest.kt
@@ -10,7 +10,6 @@ import java.nio.charset.StandardCharsets
 
 @FlowEmulatorTest
 class JsonCadenceTest {
-
     @FlowTestClient
     lateinit var flow: FlowAccessApi
 

--- a/sdk/src/intTest/org/onflow/flow/sdk/cadence/JsonCadenceTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/cadence/JsonCadenceTest.kt
@@ -3,17 +3,19 @@ package org.onflow.flow.sdk.cadence
 import kotlinx.serialization.Serializable
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.onflow.flow.common.test.FlowEmulatorTest
-import org.onflow.flow.common.test.FlowTestClient
+import org.onflow.flow.common.test.*
 import org.onflow.flow.sdk.*
+import org.onflow.flow.sdk.IntegrationTestUtils.createAndSubmitAccountCreationTransaction
 import java.nio.charset.StandardCharsets
-import org.onflow.flow.common.test.FlowTestUtil
 
 @FlowEmulatorTest
 class JsonCadenceTest {
 
     @FlowTestClient
     lateinit var flow: FlowAccessApi
+
+    @FlowServiceAccountCredentials
+    lateinit var serviceAccount: TestAccount
 
     @Serializable
     data class StorageInfo(
@@ -58,21 +60,23 @@ class JsonCadenceTest {
     }
 
     @Test
-    fun `Can parse new JSON Cadence`() {
-        val tx = when (val transactionResult = flow.getTransactionResultById(FlowId("273f68ffe175a0097db60bc7cf5e92c5a775d189af3f5636f5432c1206be771a"))) {
-            is FlowAccessApi.AccessApiCallResponse.Success -> transactionResult.data
-            is FlowAccessApi.AccessApiCallResponse.Error -> throw IllegalStateException("Failed to get transaction result: ${transactionResult.message}", transactionResult.throwable)
-        }
+    fun `Can parse JSON Cadence from transaction`() {
+        val txResult = createAndSubmitAccountCreationTransaction(
+            flow,
+            serviceAccount,
+            "cadence/transaction_creation/transaction_creation.cdc"
+        )
 
-        val events = tx.events.map { it.payload.jsonCadence }
+        assertThat(txResult).isNotNull
+        assertThat(txResult.status).isEqualTo(FlowTransactionStatus.SEALED)
+
+        val events = txResult.events.map { it.payload.jsonCadence }
         assertThat(events).hasSize(7)
     }
 
     @Test
     fun decodeOptional() {
-        val result = executeScript("cadence/json_cadence/decode_optional.cdc")
-
-        val data = when (result) {
+        val data = when (val result = executeScript("cadence/json_cadence/decode_optional.cdc")) {
             is FlowAccessApi.AccessApiCallResponse.Success -> result.data.jsonCadence.decode<Boolean?>()
             is FlowAccessApi.AccessApiCallResponse.Error -> throw IllegalStateException("Failed to execute script: ${result.message}", result.throwable)
         }
@@ -82,9 +86,7 @@ class JsonCadenceTest {
 
     @Test
     fun decodeOptional2() {
-        val result = executeScript("cadence/json_cadence/decode_optional_2.cdc")
-
-        val data = when (result) {
+        val data = when (val result = executeScript("cadence/json_cadence/decode_optional_2.cdc")) {
             is FlowAccessApi.AccessApiCallResponse.Success -> result.data.jsonCadence.decode<Boolean?>()
             is FlowAccessApi.AccessApiCallResponse.Error -> throw IllegalStateException("Failed to execute script: ${result.message}", result.throwable)
         }
@@ -94,9 +96,7 @@ class JsonCadenceTest {
 
     @Test
     fun decodeBoolean() {
-        val result = executeScript("cadence/json_cadence/decode_boolean.cdc")
-
-        val data = when (result) {
+        val data = when (val result = executeScript("cadence/json_cadence/decode_boolean.cdc")) {
             is FlowAccessApi.AccessApiCallResponse.Success -> result.data.jsonCadence.decode<Boolean?>()
             is FlowAccessApi.AccessApiCallResponse.Error -> throw IllegalStateException("Failed to execute script: ${result.message}", result.throwable)
         }
@@ -106,9 +106,7 @@ class JsonCadenceTest {
 
     @Test
     fun decodeArray() {
-        val result = executeScript("cadence/json_cadence/decode_array.cdc")
-
-        val data = when (result) {
+        val data = when (val result = executeScript("cadence/json_cadence/decode_array.cdc")) {
             is FlowAccessApi.AccessApiCallResponse.Success -> result.data.jsonCadence.decode<List<ULong>>()
             is FlowAccessApi.AccessApiCallResponse.Error -> throw IllegalStateException("Failed to execute script: ${result.message}", result.throwable)
         }
@@ -119,9 +117,7 @@ class JsonCadenceTest {
 
     @Test
     fun decodeUFix64() {
-        val result = executeScript("cadence/json_cadence/decode_ufix64.cdc")
-
-        val data = when (result) {
+        val data = when (val result = executeScript("cadence/json_cadence/decode_ufix64.cdc")) {
             is FlowAccessApi.AccessApiCallResponse.Success -> result.data.jsonCadence.decode<Double>()
             is FlowAccessApi.AccessApiCallResponse.Error -> throw IllegalStateException("Failed to execute script: ${result.message}", result.throwable)
         }
@@ -152,7 +148,7 @@ class JsonCadenceTest {
         val loadedScript = loadScriptContent("cadence/json_cadence/decode_complex_dict.cdc")
         val result = flow.simpleFlowScript {
             script { loadedScript }
-            arg { address("0x84221fe0294044d7") }
+            arg { address(serviceAccount.address) }
         }
 
         val data = when (result) {
@@ -165,9 +161,7 @@ class JsonCadenceTest {
 
     @Test
     fun decodeResource() {
-        val result = executeScript("cadence/json_cadence/decode_resource.cdc")
-
-        val decodedResource = when (result) {
+        val decodedResource = when (val result = executeScript("cadence/json_cadence/decode_resource.cdc")) {
             is FlowAccessApi.AccessApiCallResponse.Success -> result.data.jsonCadence.decode<SomeResource>()
             is FlowAccessApi.AccessApiCallResponse.Error -> throw IllegalStateException("Failed to execute script: ${result.message}", result.throwable)
         }
@@ -178,9 +172,7 @@ class JsonCadenceTest {
 
     @Test
     fun decodeEnum() {
-        val result = executeScript("cadence/json_cadence/decode_enum.cdc")
-
-        val decodedEnum = when (result) {
+        val decodedEnum = when (val result = executeScript("cadence/json_cadence/decode_enum.cdc")) {
             is FlowAccessApi.AccessApiCallResponse.Success -> result.data.jsonCadence.decode<SomeEnum>()
             is FlowAccessApi.AccessApiCallResponse.Error -> throw IllegalStateException("Failed to execute script: ${result.message}", result.throwable)
         }
@@ -191,9 +183,7 @@ class JsonCadenceTest {
 
     @Test
     fun decodeReference() {
-        val result = executeScript("cadence/json_cadence/decode_reference.cdc")
-
-        val decodedReference = when (result) {
+        val decodedReference = when (val result = executeScript("cadence/json_cadence/decode_reference.cdc")) {
             is FlowAccessApi.AccessApiCallResponse.Success -> result.data.jsonCadence.decodeToAny()
             is FlowAccessApi.AccessApiCallResponse.Error -> throw IllegalStateException("Failed to execute script: ${result.message}", result.throwable)
         }

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionCreationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionCreationTest.kt
@@ -9,7 +9,7 @@ import org.onflow.flow.common.test.FlowTestClient
 import org.onflow.flow.common.test.TestAccount
 import org.junit.jupiter.api.Test
 import org.onflow.flow.common.test.FlowTestUtil
-import org.onflow.flow.sdk.IntegrationTestUtils.getAccount
+import org.onflow.flow.sdk.IntegrationTestUtils.createAndSubmitAccountCreationTransaction
 import org.onflow.flow.sdk.IntegrationTestUtils.handleResult
 import org.onflow.flow.sdk.IntegrationTestUtils.transaction
 import java.nio.charset.StandardCharsets
@@ -50,51 +50,11 @@ class TransactionCreationTest {
 
     @Test
     fun `Can create an account using the transaction DSL`() {
-        val latestBlockId = getLatestBlockId(accessAPI)
-        val payerAccount = getAccount(accessAPI, serviceAccount.flowAddress)
-
-        val newAccountKeyPair = Crypto.generateKeyPair(SignatureAlgorithm.ECDSA_P256)
-        val newAccountPublicKey = FlowAccountKey(
-            publicKey = FlowPublicKey(newAccountKeyPair.public.hex),
-            signAlgo = SignatureAlgorithm.ECDSA_P256,
-            hashAlgo = HashAlgorithm.SHA3_256,
-            weight = 1000
+        val result = createAndSubmitAccountCreationTransaction(
+            accessAPI,
+            serviceAccount,
+            "cadence/transaction_creation/transaction_creation.cdc"
         )
-
-        val loadedScript = String(FlowTestUtil.loadScript("cadence/transaction_creation/transaction_creation.cdc"), StandardCharsets.UTF_8)
-
-        val tx = flowTransaction {
-            script {
-                loadedScript
-            }
-
-            arguments {
-                arg { string(newAccountPublicKey.encoded.bytesToHex()) }
-            }
-
-            referenceBlockId = latestBlockId
-            gasLimit = 100
-
-            proposalKey {
-                address = payerAccount.address
-                keyIndex = payerAccount.keys[0].id
-                sequenceNumber = payerAccount.keys[0].sequenceNumber.toLong()
-            }
-
-            payerAddress = payerAccount.address
-
-            signatures {
-                signature {
-                    address = payerAccount.address
-                    keyIndex = 0
-                    signer = serviceAccount.signer
-                }
-            }
-        }
-
-        val txID = handleResult(accessAPI.sendTransaction(tx), "Failed to send transaction")
-
-        val result = handleResult(waitForSeal(accessAPI, txID), "Failed to wait for seal")
 
         assertThat(result).isNotNull
         assertThat(result.status).isEqualTo(FlowTransactionStatus.SEALED)
@@ -125,10 +85,5 @@ class TransactionCreationTest {
         val result = handleResult(transactionResult, "Failed to create account")
 
         assertThat(result.status).isEqualTo(FlowTransactionStatus.SEALED)
-    }
-
-    private fun getLatestBlockId(api: FlowAccessApi): FlowId {
-        val result = api.getLatestBlockHeader()
-        return handleResult(result, "Failed to get latest block header").id
     }
 }

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -9,8 +9,6 @@ import org.onflow.flow.common.test.FlowTestAccount
 import org.onflow.flow.common.test.FlowTestClient
 import org.onflow.flow.common.test.TestAccount
 import org.onflow.flow.sdk.IntegrationTestUtils.handleResult
-import org.onflow.flow.sdk.IntegrationTestUtils.newMainnetAccessApi
-import org.onflow.flow.sdk.IntegrationTestUtils.newTestnetAccessApi
 
 @FlowEmulatorTest
 class TransactionIntegrationTest {
@@ -73,12 +71,10 @@ class TransactionIntegrationTest {
 
     @Test
     fun `Can parse events`() {
-        val accessApi = newMainnetAccessApi()
-
         // https://flowscan.org/transaction/8c2e9d37a063240f236aa181e1454eb62991b42302534d4d6dd3839c2df0ef14
         val tx = try {
             handleResult(
-                accessApi.getTransactionById(FlowId("8c2e9d37a063240f236aa181e1454eb62991b42302534d4d6dd3839c2df0ef14")),
+                accessAPI.getTransactionById(FlowId("8c2e9d37a063240f236aa181e1454eb62991b42302534d4d6dd3839c2df0ef14")),
                 "Failed to get transaction"
             )
         } catch (e: Exception) {
@@ -89,7 +85,7 @@ class TransactionIntegrationTest {
 
         val results = try {
             handleResult(
-                accessApi.getTransactionResultById(FlowId("8c2e9d37a063240f236aa181e1454eb62991b42302534d4d6dd3839c2df0ef14")),
+                accessAPI.getTransactionResultById(FlowId("8c2e9d37a063240f236aa181e1454eb62991b42302534d4d6dd3839c2df0ef14")),
                 "Failed to get transaction results"
             )
         } catch (e: Exception) {
@@ -140,8 +136,6 @@ class TransactionIntegrationTest {
 
     @Test
     fun `Can get block header by height`() {
-        val accessAPI = newMainnetAccessApi()
-
         val latestBlock = try {
             handleResult(
                 accessAPI.getLatestBlock(true),

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.onflow.flow.sdk.IntegrationTestUtils.handleResult
 
 @FlowEmulatorTest
 class TransactionIntegrationTest {
-
     @FlowTestClient
     lateinit var accessAPI: FlowAccessApi
 
@@ -19,7 +18,6 @@ class TransactionIntegrationTest {
 
     @FlowServiceAccountCredentials
     lateinit var serviceAccount: TestAccount
-
 
     @Test
     fun `Can connect to emulator and ping access API`() {

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -2,6 +2,7 @@ package org.onflow.flow.sdk.transaction
 
 import org.onflow.flow.sdk.*
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.onflow.flow.common.test.*

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -2,7 +2,6 @@ package org.onflow.flow.sdk.transaction
 
 import org.onflow.flow.sdk.*
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.onflow.flow.common.test.*

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -5,35 +5,31 @@ import org.onflow.flow.common.test.FlowEmulatorTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
+import org.onflow.flow.common.test.FlowTestAccount
+import org.onflow.flow.common.test.FlowTestClient
+import org.onflow.flow.common.test.TestAccount
 import org.onflow.flow.sdk.IntegrationTestUtils.handleResult
 import org.onflow.flow.sdk.IntegrationTestUtils.newMainnetAccessApi
 import org.onflow.flow.sdk.IntegrationTestUtils.newTestnetAccessApi
 
 @FlowEmulatorTest
 class TransactionIntegrationTest {
-    @Test
-    fun wut() {
-        val account = try {
-            handleResult(
-                newTestnetAccessApi().getAccountAtLatestBlock(FlowAddress("0x6bd3869f2631beb3")),
-                "Failed to get account"
-            )
-        } catch (e: Exception) {
-            fail("Failed to retrieve account: ${e.message}")
-        }
-        assertThat(account.keys).isNotEmpty()
-    }
+
+    @FlowTestClient
+    lateinit var accessAPI: FlowAccessApi
+
+    @FlowTestAccount
+    lateinit var testAccount: TestAccount
 
     @Test
-    fun `Can connect to mainnet`() {
-        val accessAPI = newMainnetAccessApi()
+    fun `Can connect to emulator and ping access API`() {
         try {
             handleResult(accessAPI.ping(), "Failed to ping")
         } catch (e: Exception) {
             fail("Failed to ping mainnet: ${e.message}")
         }
 
-        val address = FlowAddress("e467b9dd11fa00df")
+        val address = testAccount.flowAddress
         val account = try {
             handleResult(
                 accessAPI.getAccountAtLatestBlock(address),
@@ -44,13 +40,11 @@ class TransactionIntegrationTest {
         }
 
         assertThat(account).isNotNull
-        println(account)
         assertThat(account.keys).isNotEmpty()
     }
 
     @Test
     fun `Can get network parameters`() {
-        val accessAPI = newMainnetAccessApi()
         val networkParams = try {
             handleResult(
                 accessAPI.getNetworkParameters(),
@@ -60,12 +54,11 @@ class TransactionIntegrationTest {
             fail("Failed to retrieve network parameters: ${e.message}")
         }
 
-        assertThat(networkParams).isEqualTo(FlowChainId.MAINNET)
+        assertThat(networkParams).isEqualTo(FlowChainId.EMULATOR)
     }
 
     @Test
     fun `Can get latest protocol state snapshot`() {
-        val accessAPI = newMainnetAccessApi()
         val snapshot = try {
             handleResult(
                 accessAPI.getLatestProtocolStateSnapshot(),
@@ -122,8 +115,6 @@ class TransactionIntegrationTest {
 
     @Test
     fun `Can get block header by id`() {
-        val accessAPI = newMainnetAccessApi()
-
         val latestBlock = try {
             handleResult(
                 accessAPI.getLatestBlock(true),
@@ -177,8 +168,6 @@ class TransactionIntegrationTest {
 
     @Test
     fun `Can get latest block`() {
-        val accessAPI = newMainnetAccessApi()
-
         val latestBlock = try {
             handleResult(
                 accessAPI.getLatestBlock(true),
@@ -193,8 +182,6 @@ class TransactionIntegrationTest {
 
     @Test
     fun `Can get block by id`() {
-        val accessAPI = newMainnetAccessApi()
-
         val latestBlock = try {
             handleResult(
                 accessAPI.getLatestBlock(true),
@@ -221,8 +208,6 @@ class TransactionIntegrationTest {
 
     @Test
     fun `Can get block by height`() {
-        val accessAPI = newMainnetAccessApi()
-
         val latestBlock = try {
             handleResult(
                 accessAPI.getLatestBlock(true),
@@ -249,9 +234,7 @@ class TransactionIntegrationTest {
 
     @Test
     fun `Can get account by address`() {
-        val accessAPI = newMainnetAccessApi()
-
-        val address = FlowAddress("18eb4ee6b3c026d2")
+        val address = testAccount.flowAddress
         val account = try {
             handleResult(
                 accessAPI.getAccountByAddress(address),
@@ -267,9 +250,7 @@ class TransactionIntegrationTest {
 
     @Test
     fun `Can get account by address at latest block`() {
-        val accessAPI = newMainnetAccessApi()
-
-        val address = FlowAddress("18eb4ee6b3c026d2")
+        val address = testAccount.flowAddress
         val account = try {
             handleResult(
                 accessAPI.getAccountAtLatestBlock(address),
@@ -285,8 +266,6 @@ class TransactionIntegrationTest {
 
     @Test
     fun `Can get account by block height`() {
-        val accessAPI = newMainnetAccessApi()
-
         val latestBlock = try {
             handleResult(
                 accessAPI.getLatestBlock(true),
@@ -305,7 +284,7 @@ class TransactionIntegrationTest {
             fail("Failed to retrieve block header by height: ${e.message}")
         }
 
-        val address = FlowAddress("18eb4ee6b3c026d2")
+        val address = testAccount.flowAddress
         val account = try {
             handleResult(
                 accessAPI.getAccountByBlockHeight(address, blockHeader.height),

--- a/sdk/src/main/kotlin/resources/logback.xml
+++ b/sdk/src/main/kotlin/resources/logback.xml
@@ -6,6 +6,8 @@
         </encoder>
     </appender>
 
+    <logger name="io.netty" level="info"/>
+
     <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION

## Description

- Remove mainnet and testnet access during integration tests (tests now use emulator only) - this will alleviate existing rate limit exceeded problems on integration tests runs in GH actions
- Update netty config from DEBUG to INFO throughout the repo 

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a method for creating and submitting account creation transactions in the testing framework.
  - Enhanced logging capabilities for specific packages to improve observability and debugging.

- **Bug Fixes**
  - Improved test reliability and clarity by streamlining transaction handling and response management.

- **Refactor**
  - Reorganized test cases to eliminate redundant code and enhance readability through better dependency injection and annotation usage.
  
- **Documentation**
  - Updated method names and test descriptions for better clarity on functionality and intentions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->