### PR TITLE
Update release urls to org.onflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.onflow/flow-jvm-sdk)](https://search.maven.org/search?q=g:org.onflow%20AND%20a:flow-jvm-sdk) 
 [![Sonatype OSS](https://img.shields.io/nexus/s/org.onflow/flow-jvm-sdk?label=snapshot&server=https%3A%2F%2Fs01.oss.sonatype.org%2F)](https://s01.oss.sonatype.org/content/repositories/snapshots/org/onflow/flow-jvm-sdk/)
 
-The Flow JVM SDK is a library for JVM languages (e.g. Java, Kotlin) that provides
+The Flow JVM SDK is a library for JVM languages (e.g. Java, Kotlin, Scala, Groovy, etc) that provides
 utilities to interact with the Flow blockchain.
 
 At the moment, this SDK includes the following features:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Flow JVM SDK
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.onflow/flow-jvm-sdk)](https://search.maven.org/search?q=g:com.nftco%20AND%20a:flow-jvm-sdk) 
-[![Sonatype OSS](https://img.shields.io/nexus/s/org.onflow/flow-jvm-sdk?label=snapshot&server=https%3A%2F%2Fs01.oss.sonatype.org%2F)](https://s01.oss.sonatype.org/content/repositories/snapshots/com/nftco/flow-jvm-sdk/)
+[![Maven Central](https://img.shields.io/maven-central/v/org.onflow/flow-jvm-sdk)](https://search.maven.org/search?q=g:org.onflow%20AND%20a:flow-jvm-sdk) 
+[![Sonatype OSS](https://img.shields.io/nexus/s/org.onflow/flow-jvm-sdk?label=snapshot&server=https%3A%2F%2Fs01.oss.sonatype.org%2F)](https://s01.oss.sonatype.org/content/repositories/snapshots/org/onflow/flow-jvm-sdk/)
 
 The Flow JVM SDK is a library for JVM languages (e.g. Java, Kotlin) that provides
 utilities to interact with the Flow blockchain.


### PR DESCRIPTION


## Description

Update release urls to org.onflow

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated badge links in the README to reflect the correct organization for Maven Central and Sonatype OSS, ensuring users have accurate access to the SDK's repository locations.
	- Expanded the description of the SDK to include Scala and Groovy as supported JVM languages, enhancing clarity on its capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->