### PR TITLE
(WIP) Examples use-case - Access API subscription endpoints

### DIFF
--- a/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/streaming/streamEvents/SubscribeEventsExample.kt
+++ b/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/streaming/streamEvents/SubscribeEventsExample.kt
@@ -1,0 +1,23 @@
+package org.onflow.examples.kotlin.streaming.streamEvents
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.ReceiveChannel
+import org.onflow.examples.kotlin.AccessAPIConnector
+import org.onflow.flow.sdk.*
+import org.onflow.flow.sdk.crypto.PrivateKey
+
+class SubscribeEventsExample(
+    privateKey: PrivateKey,
+    accessApiConnection: FlowAccessApi
+) {
+    private val accessAPI = accessApiConnection
+
+    private val connector = AccessAPIConnector(privateKey, accessAPI)
+
+    fun subscribeToLatestBlockEvents(scope: CoroutineScope): Pair<ReceiveChannel<List<FlowEvent>>, ReceiveChannel<Throwable>> {
+        val blockId = connector.latestBlockID
+
+        // Subscribe to events for the latest block and return channels
+        return accessAPI.subscribeEventsByBlockId(scope, blockId)
+    }
+}

--- a/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/streaming/streamEventsReconnect/SubscribeEventsReconnectExample.kt
+++ b/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/streaming/streamEventsReconnect/SubscribeEventsReconnectExample.kt
@@ -1,0 +1,97 @@
+package org.onflow.examples.kotlin.streaming.streamEventsReconnect
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.selects.select
+import org.onflow.flow.sdk.*
+
+class SubscribeEventsReconnectExample(
+    accessApiConnection: FlowAccessApi
+) {
+    private val accessAPI = accessApiConnection
+
+    suspend fun streamEvents(scope: CoroutineScope, receivedEvents: MutableList<FlowEvent>) {
+        val header: FlowBlockHeader = getLatestBlockHeader()
+
+        val (eventChannel, errorChannel) = accessAPI.subscribeEventsByBlockId(scope, header.id)
+
+        val lastHeight = header.height
+
+        scope.launch {
+            handleEventStream(scope, eventChannel, errorChannel, lastHeight, receivedEvents)
+        }
+    }
+
+    private fun getLatestBlockHeader(): FlowBlockHeader {
+        return when (val response = accessAPI.getLatestBlockHeader(true)) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private suspend fun handleEventStream(
+        scope: CoroutineScope,
+        initialEventChannel: ReceiveChannel<List<FlowEvent>>,
+        initialErrorChannel: ReceiveChannel<Throwable>,
+        lastHeight: Long,
+        receivedEvents: MutableList<FlowEvent>
+    ) {
+        var eventChannel = initialEventChannel
+        var errorChannel = initialErrorChannel
+        var height = lastHeight
+        var reconnectAttempts = 0
+        val maxReconnectAttempts = 5
+
+        while (reconnectAttempts < maxReconnectAttempts) {
+            val shouldReconnect: Boolean = select {
+                eventChannel.onReceiveCatching { result ->
+                    result.getOrNull()?.let { events ->
+                        receivedEvents.addAll(events)
+                        println("Received events at height: $height")
+                        height++
+                        reconnectAttempts = 0 // Reset reconnect attempts on success
+                        false
+                    } ?: run {
+                        println("No events received, attempting to reconnect...")
+                        true
+                    }
+                }
+                errorChannel.onReceiveCatching { result ->
+                    result.getOrNull()?.let { error ->
+                        println("~~~ ERROR: ${error.message} ~~~")
+                        true
+                    } ?: run {
+                        true
+                    }
+                }
+                onTimeout(1000L) {
+                    println("Timeout occurred, checking channels...")
+                    false
+                }
+            }
+
+            if (shouldReconnect) {
+                reconnectAttempts++
+                if (reconnectAttempts < maxReconnectAttempts) {
+                    println("Reconnecting at block $height (attempt $reconnectAttempts/$maxReconnectAttempts)")
+                    reconnect(scope, height).let {
+                        eventChannel = it.first
+                        errorChannel = it.second
+                    }
+                } else {
+                    println("Max reconnect attempts reached. Stopping.")
+                    break
+                }
+            }
+        }
+        println("Event streaming stopped.")
+    }
+
+    private fun reconnect(
+        scope: CoroutineScope,
+        height: Long
+    ): Pair<ReceiveChannel<List<FlowEvent>>, ReceiveChannel<Throwable>> {
+        return accessAPI.subscribeEventsByBlockHeight(scope, height)
+    }
+}

--- a/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/streaming/streamExecutionData/SubscribeExecutionDataExample.kt
+++ b/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/streaming/streamExecutionData/SubscribeExecutionDataExample.kt
@@ -1,0 +1,52 @@
+package org.onflow.examples.kotlin.streaming.streamExecutionData
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.ReceiveChannel
+import org.onflow.flow.sdk.*
+
+class SubscribeExecutionDataExample(
+    private val accessAPI: FlowAccessApi
+) {
+
+    suspend fun streamExecutionData(scope: CoroutineScope, receivedExecutionData: MutableList<FlowBlockExecutionData>) {
+        val header: FlowBlockHeader = getLatestBlockHeader()
+
+        val (dataChannel, errorChannel) = accessAPI.subscribeExecutionDataByBlockId(scope, header.id)
+
+        processExecutionData(scope, dataChannel, errorChannel, receivedExecutionData)
+    }
+
+    private fun getLatestBlockHeader(): FlowBlockHeader {
+        return when (val response = accessAPI.getLatestBlockHeader(true)) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
+    }
+
+    private suspend fun processExecutionData(
+        scope: CoroutineScope,
+        dataChannel: ReceiveChannel<FlowBlockExecutionData>,
+        errorChannel: ReceiveChannel<Throwable>,
+        receivedExecutionData: MutableList<FlowBlockExecutionData>
+    ) {
+        scope.launch {
+            for (data in dataChannel) {
+                receivedExecutionData.add(data)
+            }
+        }
+
+        scope.launch {
+            for (error in errorChannel) {
+                println("~~~ ERROR: ${error.message} ~~~")
+            }
+        }
+    }
+
+
+
+
+
+
+
+    private fun ByteArray.toHexString(): String = joinToString("") { "%02x".format(it) }
+}

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEvents/SubscribeEventsExampleTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEvents/SubscribeEventsExampleTest.kt
@@ -26,6 +26,12 @@ internal class SubscribeEventsExampleTest {
         val privateKey = serviceAccount.privateKey
         subscribeEventsExample = SubscribeEventsExample(privateKey, accessAPI)
         accessAPIConnector = AccessAPIConnector(serviceAccount.privateKey, accessAPI)
+    }
+
+    @Test
+    fun `Can subscribe to latest block events`() = runBlocking {
+        val scope = this
+        val (eventChannel, errorChannel) = subscribeEventsExample.subscribeToLatestBlockEvents(scope)
 
         // Send a sample transaction to trigger events
         val publicKey = Crypto.generateKeyPair(SignatureAlgorithm.ECDSA_P256).public
@@ -33,12 +39,6 @@ internal class SubscribeEventsExampleTest {
             serviceAccount.flowAddress,
             publicKey
         )
-    }
-
-    @Test
-    fun `Can subscribe to latest block events`() = runBlocking {
-        val scope = this
-        val (eventChannel, errorChannel) = subscribeEventsExample.subscribeToLatestBlockEvents(scope)
 
         val receivedEvents = mutableListOf<FlowEvent>()
 

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEvents/SubscribeEventsExampleTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEvents/SubscribeEventsExampleTest.kt
@@ -11,7 +11,6 @@ import org.onflow.flow.sdk.crypto.Crypto
 
 @FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
 internal class SubscribeEventsExampleTest {
-
     @FlowServiceAccountCredentials
     lateinit var serviceAccount: TestAccount
 
@@ -70,4 +69,3 @@ internal class SubscribeEventsExampleTest {
         }
     }
 }
-

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEvents/SubscribeEventsExampleTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEvents/SubscribeEventsExampleTest.kt
@@ -1,0 +1,73 @@
+package org.onflow.examples.kotlin.streaming.streamEvents
+
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.onflow.examples.kotlin.AccessAPIConnector
+import org.onflow.flow.common.test.*
+import org.onflow.flow.sdk.*
+import org.onflow.flow.sdk.crypto.Crypto
+
+@FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
+internal class SubscribeEventsExampleTest {
+
+    @FlowServiceAccountCredentials
+    lateinit var serviceAccount: TestAccount
+
+    @FlowTestClient
+    lateinit var accessAPI: FlowAccessApi
+
+    private lateinit var subscribeEventsExample: SubscribeEventsExample
+    private lateinit var accessAPIConnector: AccessAPIConnector
+
+    @BeforeEach
+    fun setup() {
+        val privateKey = serviceAccount.privateKey
+        subscribeEventsExample = SubscribeEventsExample(privateKey, accessAPI)
+        accessAPIConnector = AccessAPIConnector(serviceAccount.privateKey, accessAPI)
+
+        // Send a sample transaction to trigger events
+        val publicKey = Crypto.generateKeyPair(SignatureAlgorithm.ECDSA_P256).public
+        accessAPIConnector.sendSampleTransaction(
+            serviceAccount.flowAddress,
+            publicKey
+        )
+    }
+
+    @Test
+    fun `Can subscribe to latest block events`() = runBlocking {
+        val scope = this
+        val (eventChannel, errorChannel) = subscribeEventsExample.subscribeToLatestBlockEvents(scope)
+
+        val receivedEvents = mutableListOf<FlowEvent>()
+
+        // Collect events and handle errors
+        val job = launch {
+            try {
+                for (events in eventChannel) {
+                    receivedEvents.addAll(events)
+                }
+            } catch (e: Exception) {
+                println("Error receiving events: ${e.message}")
+                e.printStackTrace()
+            } finally {
+                eventChannel.cancel()
+                errorChannel.cancel()
+            }
+        }
+
+        // Wait for events to be received
+        delay(5000L)
+        job.cancelAndJoin()
+
+        // Verify that events were received
+        assertTrue(receivedEvents.isNotEmpty(), "Should have received at least one event")
+
+        receivedEvents.forEach { event ->
+            assertNotNull(event.type, "Event type should not be null")
+            assertNotNull(event.transactionId, "Transaction ID should not be null")
+        }
+    }
+}
+

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEventsReconnect/SubscribeEventsReconnectTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEventsReconnect/SubscribeEventsReconnectTest.kt
@@ -1,0 +1,45 @@
+package org.onflow.examples.kotlin.streaming.streamEventsReconnect
+
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.onflow.flow.common.test.*
+import org.onflow.flow.sdk.*
+
+@FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
+internal class SubscribeEventsReconnectExampleTest {
+
+    @FlowTestClient
+    lateinit var accessAPI: FlowAccessApi
+
+    private lateinit var subscribeEventsReconnectExample: SubscribeEventsReconnectExample
+
+    @BeforeEach
+    fun setup() {
+        subscribeEventsReconnectExample = SubscribeEventsReconnectExample(accessAPI)
+    }
+
+    @Test
+    fun `Can stream and reconnect events`() = runBlocking {
+        val scope = this
+        val receivedEvents = mutableListOf<FlowEvent>()
+
+        val reconnectJob = launch {
+            subscribeEventsReconnectExample.streamEvents(scope, receivedEvents)
+        }
+
+        // Simulate a delay to allow event stream to start
+        delay(5000L)
+
+        // Check if the stream has reconnected and continued processing after the simulated disconnection
+        reconnectJob.cancelAndJoin()
+
+        // Validate that events have been received and processed
+        assertTrue(receivedEvents.isNotEmpty(), "Should have received at least one event")
+        receivedEvents.forEach { event ->
+            assertNotNull(event.type, "Event type should not be null")
+            assertNotNull(event.transactionId, "Transaction ID should not be null")
+        }
+    }
+}

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEventsReconnect/SubscribeEventsReconnectTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEventsReconnect/SubscribeEventsReconnectTest.kt
@@ -4,20 +4,28 @@ import kotlinx.coroutines.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.onflow.examples.kotlin.AccessAPIConnector
 import org.onflow.flow.common.test.*
 import org.onflow.flow.sdk.*
+import org.onflow.flow.sdk.crypto.Crypto
 
 @FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
 internal class SubscribeEventsReconnectExampleTest {
+
+    @FlowServiceAccountCredentials
+    lateinit var serviceAccount: TestAccount
 
     @FlowTestClient
     lateinit var accessAPI: FlowAccessApi
 
     private lateinit var subscribeEventsReconnectExample: SubscribeEventsReconnectExample
+    private lateinit var accessAPIConnector: AccessAPIConnector
 
     @BeforeEach
     fun setup() {
+        accessAPIConnector = AccessAPIConnector(serviceAccount.privateKey, accessAPI)
         subscribeEventsReconnectExample = SubscribeEventsReconnectExample(accessAPI)
+
     }
 
     @Test
@@ -31,6 +39,13 @@ internal class SubscribeEventsReconnectExampleTest {
 
         // Simulate a delay to allow event stream to start
         delay(5000L)
+
+        // Trigger a sample event
+        val publicKey = Crypto.generateKeyPair(SignatureAlgorithm.ECDSA_P256).public
+        accessAPIConnector.sendSampleTransaction(
+            serviceAccount.flowAddress,
+            publicKey
+        )
 
         // Check if the stream has reconnected and continued processing after the simulated disconnection
         reconnectJob.cancelAndJoin()

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEventsReconnect/SubscribeEventsReconnectTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamEventsReconnect/SubscribeEventsReconnectTest.kt
@@ -11,7 +11,6 @@ import org.onflow.flow.sdk.crypto.Crypto
 
 @FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
 internal class SubscribeEventsReconnectExampleTest {
-
     @FlowServiceAccountCredentials
     lateinit var serviceAccount: TestAccount
 
@@ -25,7 +24,6 @@ internal class SubscribeEventsReconnectExampleTest {
     fun setup() {
         accessAPIConnector = AccessAPIConnector(serviceAccount.privateKey, accessAPI)
         subscribeEventsReconnectExample = SubscribeEventsReconnectExample(accessAPI)
-
     }
 
     @Test

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamExecutionData/SubscribeExecutionDataExampleTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/streaming/streamExecutionData/SubscribeExecutionDataExampleTest.kt
@@ -1,0 +1,65 @@
+package org.onflow.examples.kotlin.streaming.streamExecutionData
+
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.onflow.examples.kotlin.AccessAPIConnector
+import org.onflow.flow.common.test.*
+import org.onflow.flow.sdk.*
+import org.onflow.flow.sdk.crypto.Crypto
+
+@FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
+internal class SubscribeExecutionDataExampleTest {
+
+    @FlowServiceAccountCredentials
+    lateinit var serviceAccount: TestAccount
+
+    @FlowTestClient
+    lateinit var accessAPI: FlowAccessApi
+
+    private lateinit var subscribeExecutionDataExample: SubscribeExecutionDataExample
+    private lateinit var accessAPIConnector: AccessAPIConnector
+
+    @BeforeEach
+    fun setup() {
+        accessAPIConnector = AccessAPIConnector(serviceAccount.privateKey, accessAPI)
+        subscribeExecutionDataExample = SubscribeExecutionDataExample(accessAPI)
+    }
+
+    @Test
+    fun `Can stream execution data`() = runBlocking {
+        val scope = this
+        val receivedExecutionData = mutableListOf<FlowBlockExecutionData>()
+
+        val executionDataJob = launch {
+            subscribeExecutionDataExample.streamExecutionData(scope, receivedExecutionData)
+        }
+
+        // Simulate a delay to allow execution data stream to start
+        delay(5000L)
+
+        // Trigger a sample transaction to generate execution data
+        val publicKey = Crypto.generateKeyPair(SignatureAlgorithm.ECDSA_P256).public
+        accessAPIConnector.sendSampleTransaction(
+            serviceAccount.flowAddress,
+            publicKey
+        )
+
+        delay(5000L)
+        executionDataJob.cancelAndJoin()
+
+        // Validate that execution data has been received and processed
+        assertTrue(receivedExecutionData.isNotEmpty(), "Should have received at least one block execution data")
+        receivedExecutionData.forEach { blockExecutionData ->
+            assertNotNull(blockExecutionData.blockId, "Block ID should not be null")
+            assertTrue(blockExecutionData.chunkExecutionData.isNotEmpty(), "Chunk execution data should not be empty")
+            blockExecutionData.chunkExecutionData.forEach { chunkExecutionData ->
+                assertTrue(chunkExecutionData.transactionResults.isNotEmpty(), "Transactions should not be empty")
+                chunkExecutionData.transactionResults.forEach { transaction ->
+                    assertNotNull(transaction.transactionId, "Transaction ID should not be null")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

## Description

Streaming
- Streaming events : https://github.com/onflow/flow-go-sdk/tree/master/examples/stream_events
- Streaming events and handling a reconnect when errors encountered in the stream : https://github.com/onflow/flow-go-sdk/tree/master/examples/stream_events_reconnect
- Streaming execution data : https://github.com/onflow/flow-go-sdk/tree/master/examples/stream_execution_data

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
