### PR TITLE
Update READMEs for Kotlin and Java examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This repository is organized as a multi-module project, consisting of the follow
 The core module that includes all the necessary tools and libraries to interact with the Flow blockchain. This module provides the main functionalities such as transaction preparation, signing, and interaction with the Flow Access API. 
 It also implements and tests use of the SDK via Java Annotations or Kotlin Extensions which can optionally be used when integrating.
 
-### Java Example
+### Java Examples
 This module contains example implementations demonstrating how to use the Flow JVM SDK in a Java application. It includes sample code for various use cases, making it easier for developers to understand and integrate the SDK into their Java projects.
 
 ### Kotlin Example

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ At the moment, this SDK includes the following features:
 - [x] Marshalling & unmarshalling of [JSON-Cadence](https://docs.onflow.org/cadence/json-cadence-spec/)
 - [x] DSL for creating, signing, and sending transactions and scripts
 
-## Repository modules
+## Repository structure
 
 This repository is organized as a multi-module project, consisting of the following modules:
 
 ### SDK
 The core module that includes all the necessary tools and libraries to interact with the Flow blockchain. This module provides the main functionalities such as transaction preparation, signing, and interaction with the Flow Access API. 
-It also implements and tests use of the SDK via Java Anotations or Kotlin Extensions which can optionally be used when integrating.
+It also implements and tests use of the SDK via Java Annotations or Kotlin Extensions which can optionally be used when integrating.
 
 ### Java Example
 This module contains example implementations demonstrating how to use the Flow JVM SDK in a Java application. It includes sample code for various use cases, making it easier for developers to understand and integrate the SDK into their Java projects.
@@ -28,15 +28,117 @@ This module contains example implementations demonstrating how to use the Flow J
 ### Kotlin Example
 Similar to the Java Example module, this module provides sample implementations in Kotlin. It showcases how to leverage the SDK's capabilities in a Kotlin environment.
 
+### Common utils
+The common utils module contains resources shared across all 3 above sub-modules, such as Cadence scripts and testing infrastructure.
+
 ## Contribute to this SDK
 
 We welcome all community contributions and will gladly review improvements and other proposals as PRs.
 
-Read the [contributing guide](https://github.com/onflow/flow-jvm-sdk/blob/main/CONTRIBUTING.md) to get started.
+Read the [contributing guide](./CONTRIBUTING.md) to get started.
 
 ## Dependencies
 
 This SDK requires Java Developer Kit (JDK) 8 or newer.
+
+## Getting started
+
+### Installation
+
+To add the SDK to your project, check out [this README](/sdk/README.md/#installation) for sample Maven and Gradle setup configurations.
+
+### Generating keys
+
+Flow uses [ECDSA](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm)
+to control access to user accounts. Each key pair can be used in combination with
+the SHA2-256 or SHA3-256 hashing algorithms.
+
+Here's how to generate an ECDSA key pair for the P-256 (secp256r1) curve:
+
+```kotlin
+val keyPair = Crypto.generateKeyPair(SignatureAlgorithm.ECDSA_P256)
+
+val privateKey = keyPair.private
+val publicKey = keyPair.public
+```
+One can then retrieve the hexadecimal representation of the key or encode it as bytes:
+
+```kotlin
+val privateKeyHex = privateKey.hex
+val privateKeyBytes = privateKey.hex.toByteArray()
+```
+
+#### Supported curves
+
+The example above uses an ECDSA key pair on the P-256 (secp256r1) elliptic curve.
+Flow also supports the secp256k1 curve used by Bitcoin and Ethereum.
+
+Here's how to generate an ECDSA private key for the secp256k1 curve:
+
+```kotlin
+val keyPair = Crypto.generateKeyPair(SignatureAlgorithm.ECDSA_SECP256k1)
+```
+
+Here's a full list of the supported signature and hash algorithms on Flow: [Flow Signature & Hash Algorithms](https://cadence-lang.org/docs/language/crypto#hashing).
+
+### Accessing the Flow network
+
+You can communicate with any Flow Access Node using the Flow JVM SDK. This includes official Access Nodes, nodes you run yourself, and hosted nodes. Flow JVM SDK currently only supports gRPC communication with Access Nodes.
+
+Here's how to create a new gRPC client for any network:
+
+```kotlin
+private const val MAINNET_HOSTNAME = "access.mainnet.nodes.onflow.org"
+private const val TESTNET_HOSTNAME = "access.devnet.nodes.onflow.org"
+
+fun newAccessApiConnnection(): FlowAccessApi = Flow.newAccessApi(MAINNET_HOSTNAME)
+
+val accessAPIConnection = newAccessApiConnnection()
+```
+
+### Creating an account
+
+Once you have [generated a key pair](#generating-keys), you can create a new account
+using its public key. Check out the **Create Account** example for a runnable code snippet in [Java](java-example/src/main/java/org/onflow/examples/java/createAccount/CreateAccountExample.java) or [Kotlin](kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/createAccount/CreateAccountExample.kt).
+
+### Signing transactions
+
+Transaction signing is accomplished through the `Crypto.Signer` interface. Below is a simple example of how to sign a transaction using a `PrivateKey` generated with `Crypto.generateKeyPair()`.
+
+```kotlin
+
+val latestBlockId
+val payerAddress
+val payerAccountKey
+
+var tx = FlowTransaction(
+  script = FlowScript(ExamplesUtils.loadScript(scriptName)),
+  arguments = listOf(),
+  referenceBlockId = latestBlockID,
+  gasLimit = gasLimit,
+  proposalKey = FlowTransactionProposalKey(
+    address = payerAddress,
+    keyIndex = payerAccountKey.id,
+    sequenceNumber = payerAccountKey.sequenceNumber.toLong()
+  ),
+  payerAddress = payerAddress,
+  authorizers = listOf(payerAddress)
+)
+
+val signer = Crypto.getSigner(privateKey, payerAccountKey.hashAlgo)
+tx = tx.addEnvelopeSignature(payerAddress, payerAccountKey.id, signer)
+```
+
+Check out the **Transaction Signing** example for runnable code snippets in [Java](java-example/src/main/java/org/onflow/examples/java/signTransaction/SignTransactionExample.java) or [Kotlin](kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/signTransaction/SignTransactionExample.kt).
+
+The Transaction Signing example introduces multiple transaction signing paradigms, including:
+- Single party, single signature
+- Single party, multiple signatures
+- Multiple parties
+- Multiple parties, 2 authorizers
+- Multiple parties, multiple signatures
+
+Before trying these examples, we recommend that you read through the transaction signature documentation.
 
 ## Credit
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The Flow JVM SDK is a library for JVM languages (e.g. Java, Kotlin, Scala, Groovy) that provides utilities to interact with the Flow blockchain.
 
-For a summary of the breaking changes introduced in the lastest release, please refer to [BREAKING_CHANGES.md](https://github.com/onflow/flow-jvm-sdk/blob/main/BREAKING_CHANGES.md).
+For a summary of the breaking changes introduced in the latest release, please refer to [BREAKING_CHANGES.md](./BREAKING_CHANGES.md).
 
 At the moment, this SDK includes the following features:
 - [x] Communication with the [Flow Access API](https://docs.onflow.org/access-api) over gRPC 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It also implements and tests use of the SDK via Java Annotations or Kotlin Exten
 ### Java Examples
 This module contains example implementations demonstrating how to use the Flow JVM SDK in a Java application. It includes sample code for various use cases, making it easier for developers to understand and integrate the SDK into their Java projects.
 
-### Kotlin Example
+### Kotlin Examples
 Similar to the Java Example module, this module provides sample implementations in Kotlin. It showcases how to leverage the SDK's capabilities in a Kotlin environment.
 
 ### Common Utils

--- a/README.md
+++ b/README.md
@@ -14,6 +14,30 @@ At the moment, this SDK includes the following features:
 - [x] Marshalling & unmarshalling of [JSON-Cadence](https://docs.onflow.org/cadence/json-cadence-spec/)
 - [x] DSL for creating, signing, and sending transactions and scripts
 
+## Table of Contents
+- [Repository structure](#repository-structure)
+  - [SDK](#sdk)
+  - [Java Example](#java-example)
+  - [Kotlin Example](#kotlin-example)
+  - [Common Utils](#common-utils)
+- [Contribute to this SDK](#contribute-to-this-sdk)
+- [Dependencies](#dependencies)
+- [Getting Started](#getting-started)
+  - [Installation](#installation)
+  - [Generating Keys](#generating-keys)
+  - [Supported Curves](#supported-curves)
+  - [Accessing the Flow Network](#accessing-the-flow-network)
+  - [Creating an Account](#creating-an-account)
+  - [Signing Transactions](#signing-transactions)
+  - [Sending Transactions](#sending-transactions)
+  - [Querying Transaction Results](#querying-transaction-results)
+  - [Querying Blocks](#querying-blocks)
+  - [Executing a Script](#executing-a-script)
+  - [Querying Events](#querying-events)
+  - [Querying Accounts](#querying-accounts)
+  - [Examples Summary](#examples-summary)
+- [Credit](#credit)
+
 ## Repository structure
 
 This repository is organized as a multi-module project, consisting of the following modules:
@@ -28,7 +52,7 @@ This module contains example implementations demonstrating how to use the Flow J
 ### Kotlin Example
 Similar to the Java Example module, this module provides sample implementations in Kotlin. It showcases how to leverage the SDK's capabilities in a Kotlin environment.
 
-### Common utils
+### Common Utils
 The common utils module contains resources shared across all 3 above sub-modules, such as Cadence scripts and testing infrastructure.
 
 ## Contribute to this SDK
@@ -41,13 +65,13 @@ Read the [contributing guide](./CONTRIBUTING.md) to get started.
 
 This SDK requires Java Developer Kit (JDK) 8 or newer.
 
-## Getting started
+## Getting Started
 
 ### Installation
 
 To add the SDK to your project, check out [this README](/sdk/README.md/#installation) for sample Maven and Gradle setup configurations.
 
-### Generating keys
+### Generating Keys
 
 Flow uses [ECDSA](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm)
 to control access to user accounts. Each key pair can be used in combination with
@@ -68,7 +92,7 @@ val privateKeyHex = privateKey.hex
 val privateKeyBytes = privateKey.hex.toByteArray()
 ```
 
-#### Supported curves
+#### Supported Curves
 
 The example above uses an ECDSA key pair on the P-256 (secp256r1) elliptic curve.
 Flow also supports the secp256k1 curve used by Bitcoin and Ethereum.
@@ -81,7 +105,7 @@ val keyPair = Crypto.generateKeyPair(SignatureAlgorithm.ECDSA_SECP256k1)
 
 Here's a full list of the supported signature and hash algorithms on Flow: [Flow Signature & Hash Algorithms](https://cadence-lang.org/docs/language/crypto#hashing).
 
-### Accessing the Flow network
+### Accessing the Flow Network
 
 You can communicate with any Flow Access Node using the Flow JVM SDK. This includes official Access Nodes, nodes you run yourself, and hosted nodes. Flow JVM SDK currently only supports gRPC communication with Access Nodes.
 
@@ -96,12 +120,12 @@ fun newAccessApiConnnection(): FlowAccessApi = Flow.newAccessApi(MAINNET_HOSTNAM
 val accessAPIConnection = newAccessApiConnnection()
 ```
 
-### Creating an account
+### Creating an Account
 
 Once you have [generated a key pair](#generating-keys), you can create a new account
 using its public key. Check out the **Create Account** example for a runnable code snippet in [Java](java-example/src/main/java/org/onflow/examples/java/createAccount/CreateAccountExample.java) or [Kotlin](kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/createAccount/CreateAccountExample.kt).
 
-### Signing transactions
+### Signing Transactions
 
 Transaction signing is accomplished through the `Crypto.Signer` interface. Below is a simple example of how to sign a transaction using a `PrivateKey` generated with `Crypto.generateKeyPair()`.
 
@@ -140,7 +164,7 @@ The Transaction Signing example introduces multiple transaction signing paradigm
 
 Before trying these examples, we recommend that you read through the [transaction signature documentation](https://developers.flow.com/build/basics/transactions#signing-a-transaction).
 
-### Sending transactions
+### Sending Transactions
 
 You can submit a transaction to the Flow network using the Access API client.
 
@@ -164,11 +188,11 @@ fun getTransactionResult(txID: FlowId): FlowTransactionResult = when (val respon
 
 The result includes a `status` field that will be one of the following values:
 
-`UNKNOWN` - The transaction has not yet been seen by the network.
-`PENDING` - The transaction has not yet been included in a block.
-`FINALIZED` - The transaction has been included in a block.
-`EXECUTED` - The transaction has been executed but the result has not yet been sealed.
-`SEALED` - The transaction has been executed and the result is sealed in a block.
+- `UNKNOWN` - The transaction has not yet been seen by the network.
+- `PENDING` - The transaction has not yet been included in a block.
+- `FINALIZED` - The transaction has been included in a block.
+- `EXECUTED` - The transaction has been executed but the result has not yet been sealed.
+- `SEALED` - The transaction has been executed and the result is sealed in a block.
 
 ```kotlin
 val txResult = getTransactionResult(txID)
@@ -236,7 +260,7 @@ A `FlowAccount` contains the following fields:
 `contracts`: `Map<String, FlowCode>` - The contracts deployed at this account.
 `keys`: `List<FlowAccountKey>` - A list of the public keys associated with this account.
 
-### Examples summary 
+### Examples Summary
 
 For a complete list of supported examples use-cases, see the [Examples Summary](kotlin-example/README.md/#examples-summary).
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ At the moment, this SDK includes the following features:
 ## Table of Contents
 - [Repository structure](#repository-structure)
   - [SDK](#sdk)
-  - [Java Example](#java-example)
-  - [Kotlin Example](#kotlin-example)
+  - [Java Examples](#java-examples)
+  - [Kotlin Examples](#kotlin-examples)
   - [Common Utils](#common-utils)
 - [Contribute to this SDK](#contribute-to-this-sdk)
 - [Dependencies](#dependencies)

--- a/java-example/README.md
+++ b/java-example/README.md
@@ -2,6 +2,24 @@
 
 This package contains runnable code examples that use the [Flow JVM SDK](https://github.com/onflow/flow-jvm-sdk) to interact with the Flow blockchain in Java. The examples use the [Flow Emulator](https://developers.flow.com/tools/emulator) to simulate a live network connection.
 
+## Table of Contents
+- [Running the emulator with the Flow CLI](#running-the-emulator-with-the-flow-cli)
+  - [Installation](#installation)
+- [Running the examples](#running-the-examples)
+- [Examples summary](#examples-summary)
+  - [Get blocks](#get-blocks)
+  - [Get accounts](#get-accounts)
+  - [Get events](#get-events)
+  - [Get collection](#get-collection)
+  - [Get network parameters](#get-network-parameters)
+  - [Get transactions](#get-transactions)
+  - [Sending transactions](#sending-transactions)
+  - [Execute script](#execute-script)
+  - [Create account](#create-account)
+  - [Add account key](#add-account-key)
+  - [Deploy contract](#deploy-contract)
+  - [Transaction signing](#transaction-signing)
+
 ## Running the emulator with the Flow CLI
 
 The emulator is bundled with the [Flow CLI](https://docs.onflow.org/flow-cli), a command-line interface for working with Flow.

--- a/java-example/README.md
+++ b/java-example/README.md
@@ -1,19 +1,94 @@
-# JVM SDK - Java Example
+# JVM SDK - Java Examples
 
-Example Java application using the [Flow JVM SDK](https://github.com/onflow/flow-jvm-sdk) to interact with the Flow blockchain.
+This package contains runnable code examples that use the [Flow JVM SDK](https://github.com/onflow/flow-jvm-sdk) to interact with the Flow blockchain in Java. The examples use the [Flow Emulator](https://github.com/onflow/flow/blob/master/docs/content/emulator/index.md) to simulate a live network connection.
 
-## Usage
+## Running the emulator with the Flow CLI
 
-First, install the [Flow CLI](https://docs.onflow.org/flow-cli).
+The emulator is bundled with the [Flow CLI](https://docs.onflow.org/flow-cli), a command-line interface for working with Flow.
 
-Start the [Flow Emulator](https://docs.onflow.org/emulator) in the main directory of this repository:
+### Installation
 
-```sh
-flow emulator start -v
-```
+This repository is configured to run with Cadence 1.0. Follow [these steps](https://cadence-lang.org/docs/cadence-migration-guide#install-cadence-10-cli) to install the Cadence 1.0 CLI, currently in pre-release.
 
-Then, in a separate terminal, run the application with Gradle:
+## Running the examples
 
-```sh
-./gradlew test -i
-```
+Each code example has a corresponding test file located in `/java-example/src/test`. Each test file provides a series of runnable functions which boot up the emulator and invoke the corresponding code example. We recommend using IntelliJ IDEA (see the free Community Edition [here](https://www.jetbrains.com/idea/download/)) to interact with and run the tests. However, you can also trigger an individual test run with `./gradlew :java-example:test --tests "com.example.MyTestClass.myTestMethod"`.
+
+## Examples summary
+
+Below is a list of all Java code examples currently supported in this repo:
+
+#### Get Blocks
+
+[Get blocks by ID, height, or latest sealed.](src/main/java/org/onflow/examples/java/getBlock/GetBlockAccessAPIConnector.java)
+
+- Get the latest sealed block
+- Get block by ID
+- Get block by height
+
+### Get Accounts
+
+[Get accounts by address.](src/main/java/org/onflow/examples/java/getAccount/GetAccountAccessAPIConnector.java)
+
+- Get account balance
+- Get account from the latest block
+- Get account from block by height
+
+#### Get Events
+
+[Get events emitted by transactions.](src/main/java/org/onflow/examples/java/getEvent/GetEventAccessAPIConnector.java)
+
+- Get events for height range
+- Get events for block IDs
+- Get events directly from transaction result
+
+#### Get Collection
+
+[Get collections by ID.](src/main/java/org/onflow/examples/java/getCollection/GetCollectionAccessAPIConnector.java)
+
+#### Get Network Parameters
+
+[Get the current network parameters.](src/main/java/org/onflow/examples/java/getNetworkParams/GetNetworkParametersAccessAPIConnector.java)
+
+#### Get Transactions
+
+[Get transactions.](src/main/java/org/onflow/examples/java/getTransaction/GetTransactionAccessAPIConnector.java)
+
+- Get transaction
+- Get transaction result
+
+#### Sending Transactions
+
+[Sending transactions.](src/main/java/org/onflow/examples/java/sendTransaction/SendTransactionExample.java)
+
+- Send transaction
+- Send transaction with arguments
+
+#### Execute Script
+
+[Execute a Cadence script.](src/main/java/org/onflow/examples/java/executeScript/ExecuteScriptAccessAPIConnector.java)
+
+- Execute a simple Cadence script
+- Execute a more complex Cadence script with arguments
+
+#### Create Account
+
+[Create a new account on Flow.](src/main/java/org/onflow/examples/java/createAccount/CreateAccountExample.java)
+
+#### Add Account Key
+
+[Add a key to an existing account.](src/main/java/org/onflow/examples/java/addKey/AddAccountKeyExample.java)
+
+#### Deploy Contract
+
+[Deploy a Cadence smart contract.](src/main/java/org/onflow/examples/java/deployContract/DeployContractExample.java)
+
+#### Transaction Signing
+
+[Common paradigms for signing transactions.](src/main/java/org/onflow/examples/java/signTransaction/SignTransactionExample.java)
+
+- Single party, single signature
+- Single party, multiple signatures
+- Multiple parties
+- Multiple parties, 2 authorizers
+- Multiple parties, multiple signatures

--- a/java-example/README.md
+++ b/java-example/README.md
@@ -110,3 +110,7 @@ Below is a list of all Java code examples currently supported in this repo:
 - Multiple parties
 - Multiple parties, 2 authorizers
 - Multiple parties, multiple signatures
+
+#### Unsupported Features
+
+The JVM SDK code examples currently do not support the Access API subscription endpoints (streaming events and execution data), which depend on the Execution Data API (not supported in Flow Emulator). We intend to add these examples as soon as support for these methods is released on the Flow Emulator. 

--- a/java-example/README.md
+++ b/java-example/README.md
@@ -1,6 +1,6 @@
 # JVM SDK - Java Examples
 
-This package contains runnable code examples that use the [Flow JVM SDK](https://github.com/onflow/flow-jvm-sdk) to interact with the Flow blockchain in Java. The examples use the [Flow Emulator](https://github.com/onflow/flow/blob/master/docs/content/emulator/index.md) to simulate a live network connection.
+This package contains runnable code examples that use the [Flow JVM SDK](https://github.com/onflow/flow-jvm-sdk) to interact with the Flow blockchain in Java. The examples use the [Flow Emulator](https://developers.flow.com/tools/emulator) to simulate a live network connection.
 
 ## Running the emulator with the Flow CLI
 

--- a/java-example/README.md
+++ b/java-example/README.md
@@ -26,7 +26,7 @@ Below is a list of all Java code examples currently supported in this repo:
 - Get block by ID
 - Get block by height
 
-### Get Accounts
+#### Get Accounts
 
 [Get accounts by address.](src/main/java/org/onflow/examples/java/getAccount/GetAccountAccessAPIConnector.java)
 

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -1,6 +1,6 @@
 # JVM SDK - Kotlin Examples
 
-This package contains runnable code examples that use the [Flow JVM SDK](https://github.com/onflow/flow-jvm-sdk) to interact with the Flow blockchain in Kotlin. The examples use the [Flow Emulator](https://github.com/onflow/flow/blob/master/docs/content/emulator/index.md) to simulate a live network connection.
+This package contains runnable code examples that use the [Flow JVM SDK](https://github.com/onflow/flow-jvm-sdk) to interact with the Flow blockchain in Kotlin. The examples use the [Flow Emulator](https://developers.flow.com/tools/emulator) to simulate a live network connection.
 
 ## Running the emulator with the Flow CLI
 

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -2,6 +2,24 @@
 
 This package contains runnable code examples that use the [Flow JVM SDK](https://github.com/onflow/flow-jvm-sdk) to interact with the Flow blockchain in Kotlin. The examples use the [Flow Emulator](https://developers.flow.com/tools/emulator) to simulate a live network connection.
 
+## Table of Contents
+- [Running the emulator with the Flow CLI](#running-the-emulator-with-the-flow-cli)
+    - [Installation](#installation)
+- [Running the examples](#running-the-examples)
+- [Examples summary](#examples-summary)
+    - [Get blocks](#get-blocks)
+    - [Get accounts](#get-accounts)
+    - [Get events](#get-events)
+    - [Get collection](#get-collection)
+    - [Get network parameters](#get-network-parameters)
+    - [Get transactions](#get-transactions)
+    - [Sending transactions](#sending-transactions)
+    - [Execute script](#execute-script)
+    - [Create account](#create-account)
+    - [Add account key](#add-account-key)
+    - [Deploy contract](#deploy-contract)
+    - [Transaction signing](#transaction-signing)
+    - 
 ## Running the emulator with the Flow CLI
 
 The emulator is bundled with the [Flow CLI](https://docs.onflow.org/flow-cli), a command-line interface for working with Flow. 
@@ -14,7 +32,7 @@ This repository is configured to run with Cadence 1.0. Follow [these steps](http
 
 Each code example has a corresponding test file located in `/kotlin-example/src/test`. Each test file provides a series of runnable functions which boot up the emulator and invoke the corresponding code example. We recommend using IntelliJ IDEA (see the free Community Edition [here](https://www.jetbrains.com/idea/download/)) to interact with and run the tests. However, you can also trigger an individual test run with `./gradlew :kotlin-example:test --tests "com.example.MyTestClass.myTestMethod"`. 
 
-## Examples summary 
+## Examples summary
 
 Below is a list of all Kotlin code examples currently supported in this repo:
 

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -26,7 +26,7 @@ Below is a list of all Kotlin code examples currently supported in this repo:
 - Get block by ID
 - Get block by height
 
-### Get Accounts
+#### Get Accounts
 
 [Get accounts by address.](src/main/kotlin/org/onflow/examples/kotlin/getAccount/GetAccountAccessAPIConnector.kt)
 

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -1,19 +1,94 @@
-# JVM SDK - Kotlin Example
+# JVM SDK - Kotlin Examples
 
-Example Kotlin application using the [Flow JVM SDK](https://github.com/onflow/flow-jvm-sdk) to interact with the Flow blockchain.
+This package contains runnable code examples that use the [Flow JVM SDK](https://github.com/onflow/flow-jvm-sdk) to interact with the Flow blockchain in Kotlin. The examples use the [Flow Emulator](https://github.com/onflow/flow/blob/master/docs/content/emulator/index.md) to simulate a live network connection.
 
-## Usage
+## Running the emulator with the Flow CLI
 
-First, install the [Flow CLI](https://docs.onflow.org/flow-cli).
+The emulator is bundled with the [Flow CLI](https://docs.onflow.org/flow-cli), a command-line interface for working with Flow. 
 
-Start the [Flow Emulator](https://docs.onflow.org/emulator) in the main directory of this repository:
+### Installation
 
-```sh
-flow emulator start -v
-```
+This repository is configured to run with Cadence 1.0. Follow [these steps](https://cadence-lang.org/docs/cadence-migration-guide#install-cadence-10-cli) to install the Cadence 1.0 CLI, currently in pre-release.
 
-Then, in a separate terminal, run the application with Gradle:
+## Running the examples
 
-```sh
-./gradlew test -i
-```
+Each code example has a corresponding test file located in `/kotlin-example/src/test`. Each test file provides a series of runnable functions which boot up the emulator and invoke the corresponding code example. We recommend using IntelliJ IDEA (see the free Community Edition [here](https://www.jetbrains.com/idea/download/)) to interact with and run the tests. However, you can also trigger an individual test run with `./gradlew :kotlin-example:test --tests "com.example.MyTestClass.myTestMethod"`. 
+
+## Examples summary 
+
+Below is a list of all Kotlin code examples currently supported in this repo:
+
+#### Get Blocks
+
+[Get blocks by ID, height, or latest sealed.](src/main/kotlin/org/onflow/examples/kotlin/getBlock/GetBlockAccessAPIConnector.kt)
+
+- Get the latest sealed block
+- Get block by ID
+- Get block by height
+
+### Get Accounts
+
+[Get accounts by address.](src/main/kotlin/org/onflow/examples/kotlin/getAccount/GetAccountAccessAPIConnector.kt)
+
+- Get account balance
+- Get account from the latest block
+- Get account from block by height
+
+#### Get Events
+
+[Get events emitted by transactions.](src/main/kotlin/org/onflow/examples/kotlin/getEvent/GetEventAccessAPIConnector.kt)
+
+- Get events for height range
+- Get events for block IDs
+- Get events directly from transaction result
+
+#### Get Collection
+
+[Get collections by ID.](src/main/kotlin/org/onflow/examples/kotlin/getCollection/GetCollectionAccessAPIConnector.kt)
+
+#### Get Network Parameters
+
+[Get the current network parameters.](src/main/kotlin/org/onflow/examples/kotlin/getNetworkParams/GetNetworkParametersAccessAPIConnector.kt)
+
+#### Get Transactions
+
+[Get transactions.](src/main/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnector.kt)
+
+- Get transaction 
+- Get transaction result
+
+#### Sending Transactions
+
+[Sending transactions.](src/main/kotlin/org/onflow/examples/kotlin/sendTransaction/SendTransactionExample.kt)
+
+- Send transaction
+- Send transaction with arguments
+
+#### Execute Script
+
+[Execute a Cadence script.](src/main/kotlin/org/onflow/examples/kotlin/executeScript/ExecuteScriptAccessAPIConnector.kt)
+
+- Execute a simple Cadence script
+- Execute a more complex Cadence script with arguments
+
+#### Create Account
+
+[Create a new account on Flow.](src/main/kotlin/org/onflow/examples/kotlin/createAccount/CreateAccountExample.kt)
+
+#### Add Account Key
+
+[Add a key to an existing account.](src/main/kotlin/org/onflow/examples/kotlin/addKey/AddAccountKeyExample.kt)
+
+#### Deploy Contract
+
+[Deploy a Cadence smart contract.](src/main/kotlin/org/onflow/examples/kotlin/deployContract/DeployContractExample.kt)
+
+#### Transaction Signing
+
+[Common paradigms for signing transactions.](src/main/kotlin/org/onflow/examples/kotlin/signTransaction/SignTransactionExample.kt)
+
+- Single party, single signature
+- Single party, multiple signatures
+- Multiple parties
+- Multiple parties, 2 authorizers
+- Multiple parties, multiple signatures

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -19,7 +19,7 @@ This package contains runnable code examples that use the [Flow JVM SDK](https:/
     - [Add account key](#add-account-key)
     - [Deploy contract](#deploy-contract)
     - [Transaction signing](#transaction-signing)
-    - 
+  
 ## Running the emulator with the Flow CLI
 
 The emulator is bundled with the [Flow CLI](https://docs.onflow.org/flow-cli), a command-line interface for working with Flow. 

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -110,3 +110,7 @@ Below is a list of all Kotlin code examples currently supported in this repo:
 - Multiple parties
 - Multiple parties, 2 authorizers
 - Multiple parties, multiple signatures
+
+#### Unsupported Features
+
+The JVM SDK code examples currently do not support the Access API subscription endpoints (streaming events and execution data), which depend on the Execution Data API (not supported in Flow Emulator). We intend to add these examples as soon as support for these methods is released on the Flow Emulator. 

--- a/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getEvent/GetEventAccessAPIConnector.kt
+++ b/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getEvent/GetEventAccessAPIConnector.kt
@@ -24,8 +24,7 @@ class GetEventAccessAPIConnector(
     }
 
     fun getTransactionResult(txID: FlowId): FlowTransactionResult {
-        val response = accessAPI.getTransactionResultById(txID)
-        return when (response) {
+        return when (val response = accessAPI.getTransactionResultById(txID)) {
             is FlowAccessApi.AccessApiCallResponse.Success -> response.data
             is FlowAccessApi.AccessApiCallResponse.Error -> throw RuntimeException(response.message, response.throwable)
         }

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -70,12 +70,14 @@ The jitpack.io repository is necessary to access some of the dependencies of thi
 
 ## Example usage
 
-Check out the [kotlin-example](../kotlin-example) and [java-example](../java-example) modules in this repository for examples
+Check out the [kotlin-example](../kotlin-example) and [java-example](../java-example) modules in this repository for code examples
 of how to use this SDK in your Kotlin or Java application.
 
 ## Integration tests
 
-Tests annotated with `FlowEmulatorTest` depend on the [Flow Emulator](https://github.com/onflow/flow-emulator), which is part of the [Flow CLI](https://github.com/onflow/flow-cli) to be installed on your machine.
+Tests annotated with `FlowEmulatorTest` depend on the [Flow Emulator](https://github.com/onflow/flow-emulator), which requires that the [Flow CLI](https://github.com/onflow/flow-cli) be installed on your machine.
+
+This repository is configured to run with Cadence 1.0. Follow [these steps](https://cadence-lang.org/docs/cadence-migration-guide#install-cadence-10-cli) to install the Cadence 1.0 CLI, currently in pre-release.
 
 The`FlowEmulatorTest` extension may be used by consumers of this library as well to streamline unit tests that interact
 with the FLOW blockchain. The `FlowEmulatorTest` extension uses the local flow emulator to prepare the test environment
@@ -143,16 +145,14 @@ class TransactionTest {
 
 There are two ways to test using the emulator:
 
-- `@FlowEmulatorProjectTest` - this uses a `flow.json` file that has your configuration in it
-- `@FlowEmulatorTest` - this creates a fresh and temporary flow configuration for each test
+- `@FlowEmulatorProjectTest` - this uses a `flow.json` file that has your desired configuration in it. We include a functional `flow.json` in this repo (currently used to return tests in GH Actions CICD) which should be sufficient for most use cases.
 
 Also, the following annotations are available in tests as helpers:
 
-- `@FlowTestClient` - used to inject a `FlowAccessApi` or `AsyncFlowAccessApi` into your tests
+- `@FlowTestClient` - used to inject a `FlowAccessApi` or `AsyncFlowAccessApi` instance into your tests
 - `@FlowServiceAccountCredentials` - used to inject a `TestAccount` instance into your tests that contain
   the flow service account credentials
 - `@FlowTestAccount` - used to automatically create an account in the emulator and inject a `TestAccount` instance
   containing the new account's credentials.
 
-See [ProjectTestExtensionsTest](/src/intTest/org/onflow/flow/sdk/extensions/ProjectTestExtensionsTest.kt) and
-[TestExtensionsTest](/src/intTest/org/onflow/flow/sdk/extensions/TestExtensionsTest.kt) for examples.
+See [ProjectTestExtensionsTest](/../common/src/intTest/kotlin/org/onflow/flow/common/extensions/ProjectTestExtensionsTest.kt) for example usage of the annotation.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -68,7 +68,7 @@ dependencies {
 
 The jitpack.io repository is necessary to access some of the dependencies of this library that are not available on Maven Central.
 
-## Example usage
+## Code examples
 
 Check out the [kotlin-example](../kotlin-example) and [java-example](../java-example) modules in this repository for code examples
 of how to use this SDK in your Kotlin or Java application.


### PR DESCRIPTION

## Description

Update READMEs for Kotlin and Java examples.

To-do:
Let's add a section below called 'Unsupported features'. We can summarize the missing support for Websockets and Event streaming APIs for now.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded and restructured documentation for both Java and Kotlin SDK examples.
	- Added a comprehensive "Examples summary" section for easy navigation of code examples.
	- Updated installation instructions for the Cadence 1.0 CLI.

- **Bug Fixes**
	- Enhanced clarity and usability of the README files for better user understanding.

- **Documentation**
	- Revised introductions to clarify the purpose of the examples and their usage with the Flow Emulator.
	- Improved organization and detail in the usage instructions and example functionalities.
	- Introduced a "Table of Contents" for better navigation in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->