### PR TITLE
Update flow executable name

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -40,7 +40,7 @@ sealed class AccessApiCallResponse<out T> {
 
 #### 5. Cadence 1.0 support as part of Crescendo migration
 
-- This repository has been upgraded to use Cadence 1.0 and run tests using the latest release of the Flow emulator and Flow CLI. Please ensure you have the Cadence 1.0 CLI installed on your machine (available on your system with the `flow-c1` command) before running tests and examples locally.
+- This repository has been upgraded to use Cadence 1.0 and run tests using the latest release of the Flow emulator and Flow CLI. Please ensure you have the Cadence 1.0 CLI installed on your machine (available on your system with the `flow` command) before running tests and examples locally.
 ___
 
 *Please ensure your projects are compatible with these changes before upgrading to the latest version.*

--- a/common/src/testFixtures/kotlin/org/onflow/flow/common/test/AbstractFlowEmulatorExtension.kt
+++ b/common/src/testFixtures/kotlin/org/onflow/flow/common/test/AbstractFlowEmulatorExtension.kt
@@ -35,7 +35,7 @@ annotation class FlowTestClient
 @Inherited
 @API(status = API.Status.STABLE, since = "5.0")
 annotation class FlowEmulatorCommand(
-    val value: String = "flow-c1",
+    val value: String = "flow",
     val expectedExitValue: Int = 0,
     val throwOnError: Boolean = true,
     val timeout: Long = 10,

--- a/common/src/testFixtures/kotlin/org/onflow/flow/common/test/FlowEmulatorProjectExtension.kt
+++ b/common/src/testFixtures/kotlin/org/onflow/flow/common/test/FlowEmulatorProjectExtension.kt
@@ -22,7 +22,7 @@ import java.math.BigDecimal
 @ExtendWith(FlowEmulatorProjectTestExtension::class)
 @API(status = API.Status.STABLE, since = "5.0")
 annotation class FlowEmulatorProjectTest(
-    val executable: String = "flow-c1",
+    val executable: String = "flow",
     val arguments: String = "--log debug --verbose",
     val host: String = "localhost",
     val port: Int = -1,

--- a/common/src/testFixtures/kotlin/org/onflow/flow/common/test/FlowTestUtil.kt
+++ b/common/src/testFixtures/kotlin/org/onflow/flow/common/test/FlowTestUtil.kt
@@ -121,7 +121,7 @@ object FlowTestUtil {
     @JvmStatic
     @JvmOverloads
     fun runFlow(
-        executable: String = "flow-c1",
+        executable: String = "flow",
         arguments: String? = null,
         host: String = "localhost",
         port: Int = 3570,
@@ -203,7 +203,7 @@ object FlowTestUtil {
                 listOf("${System.getProperty("user.home")}/.local/bin", "/usr/local/bin", "/usr/bin", "/bin")
                     + (System.getenv()["PATH"]?.split(File.pathSeparator) ?: emptyList())
             )
-                .map { File(it, "flow-c1") }
+                .map { File(it, "flow") }
                 .find { it.exists() }
                 ?: throw IOException("flow command not found")
         }

--- a/java-example/README.md
+++ b/java-example/README.md
@@ -27,7 +27,7 @@ The emulator is bundled with the [Flow CLI](https://docs.onflow.org/flow-cli), a
 
 ### Installation
 
-This repository is configured to run with Cadence 1.0. Follow [these steps](https://cadence-lang.org/docs/cadence-migration-guide#install-cadence-10-cli) to install the Cadence 1.0 CLI, currently in pre-release.
+This repository is configured to run with Cadence 1.0. Follow [these steps](https://cadence-lang.org/docs/cadence-migration-guide#install-cadence-10-cli) to install the Cadence 1.0 CLI.
 
 ## Running the examples
 

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -27,7 +27,7 @@ The emulator is bundled with the [Flow CLI](https://docs.onflow.org/flow-cli), a
 
 ### Installation
 
-This repository is configured to run with Cadence 1.0. Follow [these steps](https://cadence-lang.org/docs/cadence-migration-guide#install-cadence-10-cli) to install the Cadence 1.0 CLI, currently in pre-release.
+This repository is configured to run with Cadence 1.0. Follow [these steps](https://cadence-lang.org/docs/cadence-migration-guide#install-cadence-10-cli) to install the Cadence 1.0 CLI.
 
 ## Running the examples
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -77,7 +77,7 @@ of how to use this SDK in your Kotlin or Java application.
 
 Tests annotated with `FlowEmulatorTest` depend on the [Flow Emulator](https://github.com/onflow/flow-emulator), which requires that the [Flow CLI](https://github.com/onflow/flow-cli) be installed on your machine.
 
-This repository is configured to run with Cadence 1.0. Follow [these steps](https://cadence-lang.org/docs/cadence-migration-guide#install-cadence-10-cli) to install the Cadence 1.0 CLI, currently in pre-release.
+This repository is configured to run with Cadence 1.0. Follow [these steps](https://cadence-lang.org/docs/cadence-migration-guide#install-cadence-10-cli) to install the Cadence 1.0 CLI.
 
 The`FlowEmulatorTest` extension may be used by consumers of this library as well to streamline unit tests that interact
 with the FLOW blockchain. The `FlowEmulatorTest` extension uses the local flow emulator to prepare the test environment


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
	- Updated command for the Cadence 1.0 CLI from `flow-c1` to `flow` for executing tests and examples.

- **New Features**
	- Simplified command usage for the flow emulator and related tests with the new default command `flow`.

- **Documentation**
	- Clarified installation instructions for the Cadence 1.0 CLI by removing the "currently in pre-release" status across multiple README files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->