### PR TITLE
#106/ TransactionResult type differs from protobuf schema

### DIFF
--- a/java-example/README.md
+++ b/java-example/README.md
@@ -11,6 +11,7 @@ This package contains runnable code examples that use the [Flow JVM SDK](https:/
   - [Get accounts](#get-accounts)
   - [Get events](#get-events)
   - [Get collection](#get-collection)
+  - [Get execution data](#get-execution-data)
   - [Get network parameters](#get-network-parameters)
   - [Get transactions](#get-transactions)
   - [Sending transactions](#sending-transactions)
@@ -64,6 +65,10 @@ Below is a list of all Java code examples currently supported in this repo:
 #### Get Collection
 
 [Get collections by ID.](src/main/java/org/onflow/examples/java/getCollection/GetCollectionAccessAPIConnector.java)
+
+#### Get Execution Data
+
+[Get execution data by block ID.](src/main/java/org/onflow/examples/java/getExecutionData/GetExecutionDataAccessAPIConnector.java)
 
 #### Get Network Parameters
 

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -11,6 +11,7 @@ This package contains runnable code examples that use the [Flow JVM SDK](https:/
     - [Get accounts](#get-accounts)
     - [Get events](#get-events)
     - [Get collection](#get-collection)
+    - [Get execution data](#get-execution-data)
     - [Get network parameters](#get-network-parameters)
     - [Get transactions](#get-transactions)
     - [Sending transactions](#sending-transactions)
@@ -20,6 +21,7 @@ This package contains runnable code examples that use the [Flow JVM SDK](https:/
     - [Deploy contract](#deploy-contract)
     - [Transaction signing](#transaction-signing)
     - [Verifying signatures](#verifying-signatures)
+    - [Streaming events and execution data](#streaming-events-and-execution-data)
   
 ## Running the emulator with the Flow CLI
 
@@ -64,6 +66,10 @@ Below is a list of all Kotlin code examples currently supported in this repo:
 #### Get Collection
 
 [Get collections by ID.](src/main/kotlin/org/onflow/examples/kotlin/getCollection/GetCollectionAccessAPIConnector.kt)
+
+#### Get Execution Data
+
+[Get execution data by block ID.](src/main/kotlin/org/onflow/examples/kotlin/getExecutionData/GetExecutionDataAccessAPIConnector.kt)
 
 #### Get Network Parameters
 
@@ -120,6 +126,10 @@ Below is a list of all Kotlin code examples currently supported in this repo:
 - Signing an arbitrary user message and verifying it using the public keys on an account, respecting the weights of each key.
 - Signing an arbitrary user message and verifying it using the public keys on an account. Return success if any public key on the account can sign the message.
 
-#### Unsupported Features
+#### Streaming Events and Execution Data
 
-The JVM SDK code examples currently do not support the Access API subscription endpoints (streaming events and execution data), which depend on the Execution Data API (not supported in Flow Emulator). We intend to add these examples as soon as support for these methods is released on the Flow Emulator. 
+[Utilizing the Access API subscription endpoints to stream event and execution data.](src/main/kotlin/org/onflow/examples/kotlin/streaming)
+
+- Streaming events.
+- Streaming events and reconnecting in the event of a failure.
+- Streaming execution data.

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
@@ -294,6 +294,11 @@ data class FlowTransactionResult(
         .setStatus(TransactionOuterClass.TransactionStatus.valueOf(status.name))
         .setStatusCode(statusCode)
         .setErrorMessage(errorMessage)
+        .setBlockId(blockId.byteStringValue)
+        .setBlockHeight(blockHeight)
+        .setTransactionId(transactionId.byteStringValue)
+        .setCollectionId(collectionId.byteStringValue)
+        .setComputationUsage(computationUsage)
         .addAllEvents(events.map { it.builder().build() })
 
     @JvmOverloads

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
@@ -267,7 +267,12 @@ data class FlowTransactionResult(
     val status: FlowTransactionStatus,
     val statusCode: Int,
     val errorMessage: String,
-    val events: List<FlowEvent>
+    val events: List<FlowEvent>,
+    val blockId: FlowId,
+    val blockHeight: Long,
+    val transactionId: FlowId,
+    val collectionId: FlowId,
+    val computationUsage: Long
 ) : Serializable {
     companion object {
         @JvmStatic
@@ -275,7 +280,12 @@ data class FlowTransactionResult(
             status = FlowTransactionStatus.of(value.statusValue),
             statusCode = value.statusCode,
             errorMessage = value.errorMessage,
-            events = value.eventsList.map { FlowEvent.of(it) }
+            events = value.eventsList.map { FlowEvent.of(it) },
+            blockId = FlowId.of(value.blockId.toByteArray()),
+            blockHeight = value.blockHeight,
+            transactionId = FlowId.of(value.transactionId.toByteArray()),
+            collectionId = FlowId.of(value.collectionId.toByteArray()),
+            computationUsage = value.computationUsage
         )
     }
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
@@ -299,17 +299,37 @@ class FlowAccessApiTest {
     @Test
     fun `Test getTransactionResultsByBlockId with multiple results`() {
         val flowAccessApi = mock(FlowAccessApi::class.java)
-        val blockId = FlowId("01")
+        val flowId = FlowId("01")
 
-        val transactionResult1 = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message1", emptyList())
+        val transactionResult1 = FlowTransactionResult(
+            FlowTransactionStatus.SEALED,
+            1,
+            "message1",
+            emptyList(),
+            flowId,
+            1L,
+            flowId,
+            flowId,
+            1
+        )
 
-        val transactionResult2 = FlowTransactionResult(FlowTransactionStatus.SEALED, 2, "message2", emptyList())
+        val transactionResult2 = FlowTransactionResult(
+            FlowTransactionStatus.SEALED,
+            2,
+            "message2",
+            emptyList(),
+            flowId,
+            1L,
+            flowId,
+            flowId,
+            1
+        )
 
         val transactions = listOf(transactionResult1, transactionResult2)
 
-        `when`(flowAccessApi.getTransactionResultsByBlockId(blockId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(transactions))
+        `when`(flowAccessApi.getTransactionResultsByBlockId(flowId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(transactions))
 
-        val result = flowAccessApi.getTransactionResultsByBlockId(blockId)
+        val result = flowAccessApi.getTransactionResultsByBlockId(flowId)
 
         assertEquals(FlowAccessApi.AccessApiCallResponse.Success(transactions), result)
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -162,7 +162,7 @@ class AsyncFlowAccessApiImplTest {
     @Test
     fun `test getTransactionResultById`() {
         val flowId = FlowId.of("id".toByteArray())
-        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList())
+        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId,1L, flowId, flowId,1L)
         val transactionResultResponse = Access.TransactionResultResponse.newBuilder().setStatus(TransactionOuterClass.TransactionStatus.SEALED).setStatusCode(1).setErrorMessage("message").setBlockId(ByteString.copyFromUtf8("id")).build()
         `when`(api.getTransactionResult(any())).thenReturn(setupFutureMock(transactionResultResponse))
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -162,7 +162,7 @@ class AsyncFlowAccessApiImplTest {
     @Test
     fun `test getTransactionResultById`() {
         val flowId = FlowId.of("id".toByteArray())
-        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId,1L, flowId, flowId,1L)
+        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId, 1L, flowId, flowId, 1L)
         val transactionResultResponse = Access.TransactionResultResponse.newBuilder().setStatus(TransactionOuterClass.TransactionStatus.SEALED).setStatusCode(1).setErrorMessage("message").setBlockId(ByteString.copyFromUtf8("id")).build()
         `when`(api.getTransactionResult(any())).thenReturn(setupFutureMock(transactionResultResponse))
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -163,7 +163,18 @@ class AsyncFlowAccessApiImplTest {
     fun `test getTransactionResultById`() {
         val flowId = FlowId.of("id".toByteArray())
         val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId, 1L, flowId, flowId, 1L)
-        val transactionResultResponse = Access.TransactionResultResponse.newBuilder().setStatus(TransactionOuterClass.TransactionStatus.SEALED).setStatusCode(1).setErrorMessage("message").setBlockId(ByteString.copyFromUtf8("id")).build()
+
+        val transactionResultResponse = Access.TransactionResultResponse.newBuilder()
+            .setStatus(TransactionOuterClass.TransactionStatus.SEALED)
+            .setStatusCode(1)
+            .setErrorMessage("message")
+            .setBlockId(ByteString.copyFromUtf8("id"))
+            .setBlockHeight(1L)
+            .setTransactionId(ByteString.copyFromUtf8("id"))
+            .setCollectionId(ByteString.copyFromUtf8("id"))
+            .setComputationUsage(1L)
+            .build()
+
         `when`(api.getTransactionResult(any())).thenReturn(setupFutureMock(transactionResultResponse))
 
         val result = asyncFlowAccessApi.getTransactionResultById(flowId).get()

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -170,7 +170,7 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test getTransactionResultById`() {
         val flowId = FlowId.of("id".toByteArray())
-        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId,1L, flowId, flowId,1L)
+        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId, 1L, flowId, flowId, 1L)
         val response = Access.TransactionResultResponse.newBuilder().setStatus(TransactionOuterClass.TransactionStatus.SEALED).setStatusCode(1).setErrorMessage("message").setBlockId(ByteString.copyFromUtf8("id")).build()
 
         `when`(mockApi.getTransactionResult(any())).thenReturn(response)

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -170,7 +170,7 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test getTransactionResultById`() {
         val flowId = FlowId.of("id".toByteArray())
-        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList())
+        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId,1L, flowId, flowId,1L)
         val response = Access.TransactionResultResponse.newBuilder().setStatus(TransactionOuterClass.TransactionStatus.SEALED).setStatusCode(1).setErrorMessage("message").setBlockId(ByteString.copyFromUtf8("id")).build()
 
         `when`(mockApi.getTransactionResult(any())).thenReturn(response)

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -171,7 +171,17 @@ class FlowAccessApiImplTest {
     fun `Test getTransactionResultById`() {
         val flowId = FlowId.of("id".toByteArray())
         val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId, 1L, flowId, flowId, 1L)
-        val response = Access.TransactionResultResponse.newBuilder().setStatus(TransactionOuterClass.TransactionStatus.SEALED).setStatusCode(1).setErrorMessage("message").setBlockId(ByteString.copyFromUtf8("id")).build()
+
+        val response = Access.TransactionResultResponse.newBuilder()
+            .setStatus(TransactionOuterClass.TransactionStatus.SEALED)
+            .setStatusCode(1)
+            .setErrorMessage("message")
+            .setBlockId(ByteString.copyFromUtf8("id"))
+            .setBlockHeight(1L)
+            .setTransactionId(ByteString.copyFromUtf8("id"))
+            .setCollectionId(ByteString.copyFromUtf8("id"))
+            .setComputationUsage(1L)
+            .build()
 
         `when`(mockApi.getTransactionResult(any())).thenReturn(response)
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTransactionResultTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTransactionResultTest.kt
@@ -42,7 +42,19 @@ class FlowTransactionResultTest {
         val invalidStatusCode = 1
         val errorMessage = "Error message"
 
-        val flowTransactionResult = FlowTransactionResult(status, invalidStatusCode, errorMessage, emptyList())
+        val flowId = FlowId("0x1")
+
+        val flowTransactionResult = FlowTransactionResult(
+            status,
+            invalidStatusCode,
+            errorMessage,
+            emptyList(),
+            flowId,
+            1L,
+            flowId,
+            flowId,
+            1L
+        )
 
         assertThrows<FlowException> { flowTransactionResult.throwOnError() }
     }
@@ -57,11 +69,18 @@ class FlowTransactionResultTest {
         val event2 = FlowEvent("type2", FlowId("0x2234"), 0, 0, FlowEventPayload(eventField2))
         val event3 = FlowEvent("sub-type1", FlowId("0x3234"), 0, 0, FlowEventPayload(eventField3))
 
+        val flowId = FlowId("0x1")
+
         val flowTransactionResult = FlowTransactionResult(
             FlowTransactionStatus.SEALED,
             0,
             "",
-            listOf(event1, event2, event3)
+            listOf(event1, event2, event3),
+            flowId,
+            1L,
+            flowId,
+            flowId,
+            1L
         )
 
         // Events of a specific type

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTransactionResultTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTransactionResultTest.kt
@@ -34,7 +34,6 @@ class FlowTransactionResultTest {
             .setComputationUsage(1L)
             .addAllEvents(events.map { it.builder().build() })
 
-
         val flowTransactionResult = FlowTransactionResult.of(responseBuilder.build())
 
         assertEquals(status, flowTransactionResult.status)

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTransactionResultTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTransactionResultTest.kt
@@ -28,6 +28,7 @@ class FlowTransactionResultTest {
             .setErrorMessage(errorMessage)
             .addAllEvents(events.map { it.builder().build() })
 
+
         val flowTransactionResult = FlowTransactionResult.of(responseBuilder.build())
 
         assertEquals(status, flowTransactionResult.status)
@@ -42,7 +43,7 @@ class FlowTransactionResultTest {
         val invalidStatusCode = 1
         val errorMessage = "Error message"
 
-        val flowId = FlowId("0x1")
+        val flowId = FlowId("0x01")
 
         val flowTransactionResult = FlowTransactionResult(
             status,
@@ -69,7 +70,7 @@ class FlowTransactionResultTest {
         val event2 = FlowEvent("type2", FlowId("0x2234"), 0, 0, FlowEventPayload(eventField2))
         val event3 = FlowEvent("sub-type1", FlowId("0x3234"), 0, 0, FlowEventPayload(eventField3))
 
-        val flowId = FlowId("0x1")
+        val flowId = FlowId("0x01")
 
         val flowTransactionResult = FlowTransactionResult(
             FlowTransactionStatus.SEALED,

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTransactionResultTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTransactionResultTest.kt
@@ -1,5 +1,6 @@
 package org.onflow.flow.sdk.models
 
+import com.google.protobuf.ByteString
 import org.onflow.flow.sdk.*
 import org.onflow.flow.sdk.cadence.CompositeAttribute
 import org.onflow.flow.sdk.cadence.CompositeValue
@@ -26,6 +27,11 @@ class FlowTransactionResultTest {
             .setStatus(TransactionOuterClass.TransactionStatus.EXECUTED)
             .setStatusCode(statusCode)
             .setErrorMessage(errorMessage)
+            .setBlockId(ByteString.copyFromUtf8("blockId"))
+            .setBlockHeight(1L)
+            .setTransactionId(ByteString.copyFromUtf8("transactionId"))
+            .setCollectionId(ByteString.copyFromUtf8("collectionId"))
+            .setComputationUsage(1L)
             .addAllEvents(events.map { it.builder().build() })
 
 


### PR DESCRIPTION
Closes: #106 

## Description

Adds the missing fields to `FlowTransactionResult`:
- `computationUsage`

As well as missing fields which the Go SDK had but the JVM SDK did not:
- `blockId`
- `blockHeight`
- `collectionId`
- `transactionId`
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added new sections in documentation for "Get Execution Data" and "Streaming Events and Execution Data" in both Java and Kotlin examples, enhancing user guidance on retrieving execution data.
  
- **Bug Fixes**
  - Improved error handling in subscription tests for execution data and events to ensure proper exception management.

- **Documentation**
  - Updated README files to include new examples and improved formatting for clarity and consistency.
  - Enhanced the "Examples summary" section in both Java and Kotlin documentation to reflect new entries.
  - Added detailed descriptions and links to relevant code examples for better user understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->