### PR TITLE
#110/ CollectionGuarantee type differs from protobuf schema 

### DIFF
--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
@@ -644,6 +644,10 @@ data class FlowBlock(
     val collectionGuarantees: List<FlowCollectionGuarantee>,
     val blockSeals: List<FlowBlockSeal>,
     val signatures: List<FlowSignature>,
+    val executionReceiptMetalist,
+    val exectionResultList,
+    val blockHeader,
+    val protocolStateId
 ) : Serializable {
     companion object {
         @JvmStatic

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
@@ -918,13 +918,19 @@ data class FlowBlockExecutionData(
 
 data class FlowCollectionGuarantee(
     val id: FlowId,
-    val signatures: List<FlowSignature>
+    val signatures: List<FlowSignature>,
+    val referenceBlockId: FlowId,
+    val signature: FlowSignature,
+    val signerIndices: ByteArray
 ) : Serializable {
     companion object {
         @JvmStatic
         fun of(value: CollectionOuterClass.CollectionGuarantee) = FlowCollectionGuarantee(
             id = FlowId.of(value.collectionId.toByteArray()),
-            signatures = value.signaturesList.map { FlowSignature(it.toByteArray()) }
+            signatures = value.signaturesList.map { FlowSignature(it.toByteArray()) },
+            referenceBlockId = FlowId.of(value.referenceBlockId.toByteArray()),
+            signature = FlowSignature(value.signature.toByteArray()),
+            signerIndices = value.signerIndices.toByteArray()
         )
     }
 
@@ -932,6 +938,31 @@ data class FlowCollectionGuarantee(
     fun builder(builder: CollectionOuterClass.CollectionGuarantee.Builder = CollectionOuterClass.CollectionGuarantee.newBuilder()): CollectionOuterClass.CollectionGuarantee.Builder = builder
         .setCollectionId(id.byteStringValue)
         .addAllSignatures(signatures.map { it.byteStringValue })
+        .setReferenceBlockId(referenceBlockId.byteStringValue)
+        .setSignature(signature.byteStringValue)
+        .setSignerIndices(UnsafeByteOperations.unsafeWrap(signerIndices))
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FlowCollectionGuarantee) return false
+
+        if (id != other.id) return false
+        if (signatures != other.signatures) return false
+        if (referenceBlockId != other.referenceBlockId) return false
+        if (signature != other.signature) return false
+        if (!signerIndices.contentEquals(other.signerIndices)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + signatures.hashCode()
+        result = 31 * result + referenceBlockId.hashCode()
+        result = 31 * result + signature.hashCode()
+        result = 31 * result + signerIndices.contentHashCode()
+        return result
+    }
 }
 
 data class FlowBlockSeal(

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
@@ -665,6 +665,16 @@ data class FlowBlockHeader(
         .setId(id.byteStringValue)
         .setParentId(parentId.byteStringValue)
         .setHeight(height)
+        .setTimestamp(timestamp.asTimestamp())
+        .setPayloadHash(UnsafeByteOperations.unsafeWrap(payloadHash))
+        .setView(view)
+        .setParentVoterSigData(UnsafeByteOperations.unsafeWrap(parentVoterSigData))
+        .setProposerId(proposerId.byteStringValue)
+        .setProposerSigData(UnsafeByteOperations.unsafeWrap(proposerSigData))
+        .setChainId(chainId.id)
+        .setParentVoterIndices(UnsafeByteOperations.unsafeWrap(parentVoterIndices))
+        .setLastViewTc(lastViewTc.builder().build())
+        .setParentView(parentView)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -744,6 +754,11 @@ data class FlowBlock(
         .addAllCollectionGuarantees(collectionGuarantees.map { it.builder().build() })
         .addAllBlockSeals(blockSeals.map { it.builder().build() })
         .addAllSignatures(signatures.map { it.byteStringValue })
+        .addAllExecutionReceiptMetaList(executionReceiptMetaList.map { it.builder().build() })
+        .addAllExecutionResultList(executionResultList.map { it.builder().build() })
+        .setBlockHeader(blockHeader.builder().build())
+        .setProtocolStateId(protocolStateId.byteStringValue)
+
 }
 
 data class FlowChunk(
@@ -772,6 +787,19 @@ data class FlowChunk(
             stateDeltaCommitment = grpcExecutionResult.stateDeltaCommitment.toByteArray()
         )
     }
+
+    @JvmOverloads
+    fun builder(builder: ExecutionResultOuterClass.Chunk.Builder = ExecutionResultOuterClass.Chunk.newBuilder()): ExecutionResultOuterClass.Chunk.Builder = builder
+        .setCollectionIndex(collectionIndex)
+        .setStartState(ByteString.copyFrom(startState))
+        .setEventCollection(ByteString.copyFrom(eventCollection))
+        .setBlockId(blockId.byteStringValue)
+        .setTotalComputationUsed(totalComputationUsed)
+        .setNumberOfTransactions(numberOfTransactions)
+        .setIndex(index)
+        .setEndState(ByteString.copyFrom(endState))
+        .setExecutionDataId(executionDataId.byteStringValue)
+        .setStateDeltaCommitment(ByteString.copyFrom(stateDeltaCommitment))
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -817,6 +845,11 @@ data class FlowServiceEvent(
         )
     }
 
+    @JvmOverloads
+    fun builder(builder: ExecutionResultOuterClass.ServiceEvent.Builder = ExecutionResultOuterClass.ServiceEvent.newBuilder()): ExecutionResultOuterClass.ServiceEvent.Builder = builder
+        .setType(type)
+        .setPayload(ByteString.copyFrom(payload))
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is FlowServiceEvent) return false
@@ -854,9 +887,14 @@ data class FlowExecutionResult(
             chunks = grpcExecutionResult.chunksList.map { FlowChunk.of(it) },
             serviceEvents = grpcExecutionResult.serviceEventsList.map { FlowServiceEvent.of(it) },
         )
-
-
     }
+
+    @JvmOverloads
+    fun builder(builder: ExecutionResultOuterClass.ExecutionResult.Builder = ExecutionResultOuterClass.ExecutionResult.newBuilder()): ExecutionResultOuterClass.ExecutionResult.Builder = builder
+        .setBlockId(blockId.byteStringValue)
+        .setPreviousResultId(previousResultId.byteStringValue)
+        .addAllChunks(chunks.map { it.builder().build() })
+        .addAllServiceEvents(serviceEvents.map { it.builder().build() })
 }
 
 data class FlowExecutionReceiptMeta(
@@ -873,6 +911,13 @@ data class FlowExecutionReceiptMeta(
             executorSignature = FlowSignature(grpcExecutionResult.executorSignature.toByteArray())
         )
     }
+
+    @JvmOverloads
+    fun builder(builder: ExecutionResultOuterClass.ExecutionReceiptMeta.Builder = ExecutionResultOuterClass.ExecutionReceiptMeta.newBuilder()): ExecutionResultOuterClass.ExecutionReceiptMeta.Builder = builder
+        .setExecutorId(executorId.byteStringValue)
+        .setResultId(resultId.byteStringValue)
+        .addAllSpocks(spocks.map { ByteString.copyFrom(it) })
+        .setExecutorSignature(executorSignature.byteStringValue)
 }
 
 data class FlowTimeoutCertificate(
@@ -891,6 +936,14 @@ data class FlowTimeoutCertificate(
             sigData = grpcExecutionResult.sigData.toByteArray()
         )
     }
+
+    @JvmOverloads
+    fun builder(builder: BlockHeaderOuterClass.TimeoutCertificate.Builder = BlockHeaderOuterClass.TimeoutCertificate.newBuilder()): BlockHeaderOuterClass.TimeoutCertificate.Builder = builder
+        .setView(view)
+        .addAllHighQcViews(highQcViews)
+        .setHighestQc(highestQc.builder().build())
+        .setSignerIndices(ByteString.copyFrom(signerIndices))
+        .setSigData(ByteString.copyFrom(sigData))
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -929,6 +982,13 @@ data class FlowQuorumCertificate(
             sigData = grpcExecutionResult.sigData.toByteArray()
         )
     }
+
+    @JvmOverloads
+    fun builder(builder: BlockHeaderOuterClass.QuorumCertificate.Builder = BlockHeaderOuterClass.QuorumCertificate.newBuilder()): BlockHeaderOuterClass.QuorumCertificate.Builder = builder
+        .setView(view)
+        .setBlockId(blockId.byteStringValue)
+        .setSignerIndices(ByteString.copyFrom(signerIndices))
+        .setSigData(ByteString.copyFrom(sigData))
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
@@ -758,7 +758,6 @@ data class FlowBlock(
         .addAllExecutionResultList(executionResultList.map { it.builder().build() })
         .setBlockHeader(blockHeader.builder().build())
         .setProtocolStateId(protocolStateId.byteStringValue)
-
 }
 
 data class FlowChunk(

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
@@ -644,10 +644,10 @@ data class FlowBlock(
     val collectionGuarantees: List<FlowCollectionGuarantee>,
     val blockSeals: List<FlowBlockSeal>,
     val signatures: List<FlowSignature>,
-    val executionReceiptMetalist,
-    val exectionResultList,
-    val blockHeader,
-    val protocolStateId
+    val executionReceiptMetalist: List<FlowExecutionReceiptMeta>,
+    val exectionResultList: List<FlowExecutionResult>,
+    val blockHeader: FlowBlockHeader,
+    val protocolStateId: FlowId
 ) : Serializable {
     companion object {
         @JvmStatic
@@ -659,6 +659,10 @@ data class FlowBlock(
             collectionGuarantees = value.collectionGuaranteesList.map { FlowCollectionGuarantee.of(it) },
             blockSeals = value.blockSealsList.map { FlowBlockSeal.of(it) },
             signatures = value.signaturesList.map { FlowSignature(it.toByteArray()) },
+            executionReceiptMetalist = value.executionReceiptMetaListList.map { FlowExecutionReceiptMeta(it.toByteArray()) },
+            exectionResultList = value.executionResultListList.map { FlowExecutionResult.of(it)},
+            blockHeader = FlowBlockHeader.of(value.blockHeader),
+            protocolStateId =  FlowId.of(value.protocolStateId.toByteArray())
         )
     }
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -29,6 +29,36 @@ class AsyncFlowAccessApiImplTest {
     companion object {
         val BLOCK_ID_BYTES = byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
         val PARENT_ID_BYTES = byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2)
+
+        const val HEIGHT = 123L
+
+        val mockBlockHeader = FlowBlockHeader(
+            id = FlowId.of(BLOCK_ID_BYTES),
+            parentId = FlowId.of(PARENT_ID_BYTES),
+            height = 123L,
+            timestamp = LocalDateTime.of(2024, 10, 15, 18, 33, 12),
+            payloadHash = ByteArray(32) { 0 },
+            view = 1L,
+            parentVoterSigData = ByteArray(32) { 0 },
+            proposerId = FlowId.of(PARENT_ID_BYTES),
+            proposerSigData = ByteArray(32) { 0 },
+            chainId = FlowChainId.MAINNET,
+            parentVoterIndices = ByteArray(32) { 0 },
+            lastViewTc = FlowTimeoutCertificate(
+                view = 1L,
+                highQcViews = emptyList(),
+                highestQc = FlowQuorumCertificate(
+                    view = 1L,
+                    blockId = FlowId.of(BLOCK_ID_BYTES),
+                    signerIndices = ByteArray(32) { 0 },
+                    sigData = ByteArray(32) { 0 }
+                ),
+                signerIndices = ByteArray(32) { 0 },
+                sigData = ByteArray(32) { 0 }
+            ),
+            parentView = 1L
+        )
+
     }
 
     private fun <T> setupFutureMock(response: T): ListenableFuture<T> {
@@ -48,7 +78,7 @@ class AsyncFlowAccessApiImplTest {
 
     @Test
     fun `test getLatestBlockHeader`() {
-        val mockBlockHeader = FlowBlockHeader(FlowId("01"), FlowId("01"), 123L)
+        val mockBlockHeader = mockBlockHeader
         val blockHeaderResponse = Access.BlockHeaderResponse.newBuilder().setBlock(mockBlockHeader.builder().build()).build()
         `when`(api.getLatestBlockHeader(any())).thenReturn(setupFutureMock(blockHeaderResponse))
 
@@ -60,8 +90,8 @@ class AsyncFlowAccessApiImplTest {
 
     @Test
     fun `test getBlockHeaderById`() {
-        val blockId = FlowId("01")
-        val mockBlockHeader = FlowBlockHeader(blockId, FlowId("01"), 123L)
+        val blockId = FlowId.of(BLOCK_ID_BYTES)
+        val mockBlockHeader = mockBlockHeader
         val blockHeaderResponse = Access.BlockHeaderResponse.newBuilder().setBlock(mockBlockHeader.builder().build()).build()
         `when`(api.getBlockHeaderByID(any())).thenReturn(setupFutureMock(blockHeaderResponse))
 
@@ -73,8 +103,8 @@ class AsyncFlowAccessApiImplTest {
 
     @Test
     fun `test getBlockHeaderByHeight`() {
-        val height = 123L
-        val mockBlockHeader = FlowBlockHeader(FlowId("01"), FlowId("01"), height)
+        val height = HEIGHT
+        val mockBlockHeader = mockBlockHeader
         val blockHeaderResponse = Access.BlockHeaderResponse.newBuilder().setBlock(mockBlockHeader.builder().build()).build()
         `when`(api.getBlockHeaderByHeight(any())).thenReturn(setupFutureMock(blockHeaderResponse))
 
@@ -86,7 +116,19 @@ class AsyncFlowAccessApiImplTest {
 
     @Test
     fun `test getLatestBlock`() {
-        val mockBlock = FlowBlock(FlowId("01"), FlowId("01"), 123L, LocalDateTime.now(), emptyList(), emptyList(), emptyList())
+        val mockBlock = FlowBlock(
+            id = FlowId.of(BLOCK_ID_BYTES),
+            parentId = FlowId.of(PARENT_ID_BYTES),
+            height = 123L,
+            timestamp = LocalDateTime.now(),
+            collectionGuarantees = emptyList(),
+            blockSeals = emptyList(),
+            signatures = emptyList(),
+            executionReceiptMetaList = emptyList(),
+            executionResultList = emptyList(),
+            blockHeader = mockBlockHeader,
+            protocolStateId = FlowId.of(ByteArray(32))
+        )
         val blockResponse = Access.BlockResponse.newBuilder().setBlock(mockBlock.builder().build()).build()
         `when`(api.getLatestBlock(any())).thenReturn(setupFutureMock(blockResponse))
 
@@ -98,8 +140,20 @@ class AsyncFlowAccessApiImplTest {
 
     @Test
     fun `test getBlockById`() {
-        val blockId = FlowId("01")
-        val mockBlock = FlowBlock(blockId, FlowId("01"), 123L, LocalDateTime.now(), emptyList(), emptyList(), emptyList())
+        val blockId = FlowId.of(BLOCK_ID_BYTES)
+        val mockBlock = FlowBlock(
+            id = blockId,
+            parentId = FlowId.of(PARENT_ID_BYTES),
+            height = 123L,
+            timestamp = LocalDateTime.now(),
+            collectionGuarantees = emptyList(),
+            blockSeals = emptyList(),
+            signatures = emptyList(),
+            executionReceiptMetaList = emptyList(),
+            executionResultList = emptyList(),
+            blockHeader = mockBlockHeader,
+            protocolStateId = FlowId.of(ByteArray(32))
+        )
         val blockResponse = Access.BlockResponse.newBuilder().setBlock(mockBlock.builder().build()).build()
         `when`(api.getBlockByID(any())).thenReturn(setupFutureMock(blockResponse))
 
@@ -111,8 +165,20 @@ class AsyncFlowAccessApiImplTest {
 
     @Test
     fun `test getBlockByHeight`() {
-        val height = 123L
-        val mockBlock = FlowBlock(FlowId("01"), FlowId("01"), height, LocalDateTime.now(), emptyList(), emptyList(), emptyList())
+        val height = HEIGHT
+        val mockBlock = FlowBlock(
+            FlowId("01"),
+            FlowId("01"),
+            height,
+            LocalDateTime.now(),
+            emptyList(),
+            emptyList(),
+            emptyList(),
+            emptyList(),
+            emptyList(),
+            mockBlockHeader,
+            FlowId.of(ByteArray(32))
+        )
         val blockResponse = Access.BlockResponse.newBuilder().setBlock(mockBlock.builder().build()).build()
         `when`(api.getBlockByHeight(any())).thenReturn(setupFutureMock(blockResponse))
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -58,7 +58,6 @@ class AsyncFlowAccessApiImplTest {
             ),
             parentView = 1L
         )
-
     }
 
     private fun <T> setupFutureMock(response: T): ListenableFuture<T> {

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -32,10 +32,29 @@ class FlowAccessApiImplTest {
     private lateinit var outputStreamCaptor: ByteArrayOutputStream
     private lateinit var originalOut: PrintStream
 
-    private val api = mock(AccessAPIGrpc.AccessAPIBlockingStub::class.java)
-    private val executionDataApi = mock(ExecutionDataAPIGrpc.ExecutionDataAPIBlockingStub::class.java)
     private val testDispatcher = TestCoroutineDispatcher()
     private val testScope = TestCoroutineScope(testDispatcher)
+
+    companion object {
+        val mockBlockHeader = FlowBlockHeader(
+            id = FlowId.of(AsyncFlowAccessApiImplTest.BLOCK_ID_BYTES),
+            parentId = FlowId.of(AsyncFlowAccessApiImplTest.PARENT_ID_BYTES),
+            height = 123L,
+            timestamp = LocalDateTime.now(),
+            payloadHash = ByteArray(32),
+            view = 1L,
+            parentVoterSigData = ByteArray(32),
+            proposerId = FlowId.of(AsyncFlowAccessApiImplTest.PARENT_ID_BYTES),
+            proposerSigData = ByteArray(32),
+            chainId = FlowChainId.MAINNET,
+            parentVoterIndices = ByteArray(32),
+            lastViewTc = FlowTimeoutCertificate(1L, emptyList(), FlowQuorumCertificate(1L, FlowId.of(AsyncFlowAccessApiImplTest.BLOCK_ID_BYTES), ByteArray(32), ByteArray(32)), ByteArray(32), ByteArray(32)),
+            parentView = 1L
+        )
+
+        val blockId = FlowId("01")
+        val mockBlock = FlowBlock(blockId, FlowId("01"), 123L, LocalDateTime.now(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), mockBlockHeader, FlowId("01"))
+    }
 
     @BeforeEach
     fun setUp() {
@@ -60,7 +79,7 @@ class FlowAccessApiImplTest {
 
     @Test
     fun `Test getLatestBlockHeader`() {
-        val mockBlockHeader = FlowBlockHeader(FlowId("01"), FlowId("01"), 123L)
+        val mockBlockHeader = mockBlockHeader
         val blockHeaderProto = Access.BlockHeaderResponse.newBuilder().setBlock(mockBlockHeader.builder().build()).build()
 
         `when`(mockApi.getLatestBlockHeader(any())).thenReturn(blockHeaderProto)
@@ -71,8 +90,8 @@ class FlowAccessApiImplTest {
 
     @Test
     fun `Test getBlockHeaderById`() {
-        val blockId = FlowId("01")
-        val mockBlockHeader = FlowBlockHeader(blockId, FlowId("01"), 123L)
+        val blockId = blockId
+        val mockBlockHeader = mockBlockHeader
         val blockHeaderProto = Access.BlockHeaderResponse.newBuilder().setBlock(mockBlockHeader.builder().build()).build()
 
         `when`(mockApi.getBlockHeaderByID(any())).thenReturn(blockHeaderProto)
@@ -84,7 +103,7 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test getBlockHeaderByHeight`() {
         val height = 123L
-        val mockBlockHeader = FlowBlockHeader(FlowId("01"), FlowId("01"), height)
+        val mockBlockHeader = mockBlockHeader
         val blockHeaderProto = Access.BlockHeaderResponse.newBuilder().setBlock(mockBlockHeader.builder().build()).build()
 
         `when`(mockApi.getBlockHeaderByHeight(any())).thenReturn(blockHeaderProto)
@@ -95,7 +114,7 @@ class FlowAccessApiImplTest {
 
     @Test
     fun `Test getLatestBlock`() {
-        val mockBlock = FlowBlock(FlowId("01"), FlowId("01"), 123L, LocalDateTime.now(), emptyList(), emptyList(), emptyList())
+        val mockBlock = mockBlock
         val blockProto = Access.BlockResponse.newBuilder().setBlock(mockBlock.builder().build()).build()
 
         `when`(mockApi.getLatestBlock(any())).thenReturn(blockProto)
@@ -106,9 +125,9 @@ class FlowAccessApiImplTest {
 
     @Test
     fun `Test getBlockById`() {
-        val blockId = FlowId("01")
-        val mockBlock = FlowBlock(blockId, FlowId("01"), 123L, LocalDateTime.now(), emptyList(), emptyList(), emptyList())
+        val blockId = blockId
         val blockProto = Access.BlockResponse.newBuilder().setBlock(mockBlock.builder().build()).build()
+        val mockBlock = mockBlock
 
         `when`(mockApi.getBlockByID(any())).thenReturn(blockProto)
 
@@ -119,7 +138,7 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test getBlockByHeight`() {
         val height = 123L
-        val mockBlock = FlowBlock(FlowId("01"), FlowId("01"), height, LocalDateTime.now(), emptyList(), emptyList(), emptyList())
+        val mockBlock = mockBlock
         val blockProto = Access.BlockResponse.newBuilder().setBlock(mockBlock.builder().build()).build()
 
         `when`(mockApi.getBlockByHeight(any())).thenReturn(blockProto)

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockHeaderTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockHeaderTest.kt
@@ -1,4 +1,248 @@
 package org.onflow.flow.sdk.models
 
+import com.google.protobuf.ByteString
+import com.google.protobuf.UnsafeByteOperations
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.onflow.flow.sdk.*
+import org.onflow.protobuf.entities.BlockHeaderOuterClass
+import java.time.LocalDateTime
+
 class FlowBlockHeaderTest {
+    companion object {
+        val idBytes = ByteArray(32) { 0x01 }
+        val parentIdBytes = ByteArray(32) { 0x02 }
+        val proposerIdBytes = ByteArray(32) { 0x03 }
+        val payloadHashBytes = ByteArray(32) { 0x04 }
+        val voterSigDataBytes = ByteArray(32) { 0x05 }
+        val proposerSigDataBytes = ByteArray(32) { 0x06 }
+        val voterIndicesBytes = ByteArray(32) { 0x07 }
+
+        val id = FlowId.of(idBytes)
+        val parentId = FlowId.of(parentIdBytes)
+        val proposerId = FlowId.of(proposerIdBytes)
+        val chainId = FlowChainId.of("mainnet")
+        val timestamp = LocalDateTime.now()
+        val timeoutCertificate = mock(FlowTimeoutCertificate::class.java)
+    }
+    @Test
+    fun `test of() method`() {
+        val chainId = "mainnet"
+
+        // Mock block header
+        val grpcBlockHeader = mock(BlockHeaderOuterClass.BlockHeader::class.java)
+        `when`(grpcBlockHeader.id).thenReturn(ByteString.copyFrom(idBytes))
+        `when`(grpcBlockHeader.parentId).thenReturn(ByteString.copyFrom(parentIdBytes))
+        `when`(grpcBlockHeader.height).thenReturn(123L)
+        `when`(grpcBlockHeader.timestamp).thenReturn(timestamp.asTimestamp())
+        `when`(grpcBlockHeader.payloadHash).thenReturn(ByteString.copyFrom(payloadHashBytes))
+        `when`(grpcBlockHeader.view).thenReturn(456L)
+        `when`(grpcBlockHeader.parentVoterSigData).thenReturn(ByteString.copyFrom(voterSigDataBytes))
+        `when`(grpcBlockHeader.proposerId).thenReturn(ByteString.copyFrom(proposerIdBytes))
+        `when`(grpcBlockHeader.proposerSigData).thenReturn(ByteString.copyFrom(proposerSigDataBytes))
+        `when`(grpcBlockHeader.chainId).thenReturn(chainId)
+        `when`(grpcBlockHeader.parentVoterIndices).thenReturn(ByteString.copyFrom(voterIndicesBytes))
+
+        // Mock timeout certificate and quorum certificate
+        val timeoutCertificateMock = mock(BlockHeaderOuterClass.TimeoutCertificate::class.java)
+        `when`(timeoutCertificateMock.signerIndices).thenReturn(ByteString.copyFrom(idBytes))
+        `when`(timeoutCertificateMock.sigData).thenReturn(ByteString.copyFrom(idBytes))
+
+        val highestQcMock = mock(BlockHeaderOuterClass.QuorumCertificate::class.java)
+        `when`(highestQcMock.blockId).thenReturn(ByteString.copyFrom(idBytes))
+        `when`(highestQcMock.signerIndices).thenReturn(ByteString.copyFrom(idBytes))
+        `when`(highestQcMock.sigData).thenReturn(ByteString.copyFrom(idBytes))
+
+        `when`(grpcBlockHeader.lastViewTc).thenReturn(timeoutCertificateMock)
+        `when`(timeoutCertificateMock.highestQc).thenReturn(highestQcMock)
+        `when`(grpcBlockHeader.parentView).thenReturn(789L)
+
+        val flowBlockHeader = FlowBlockHeader.of(grpcBlockHeader)
+
+        assertEquals(FlowId.of(idBytes), flowBlockHeader.id)
+        assertEquals(FlowId.of(parentIdBytes), flowBlockHeader.parentId)
+        assertEquals(123L, flowBlockHeader.height)
+        assertEquals(timestamp, flowBlockHeader.timestamp)
+        assertArrayEquals(payloadHashBytes, flowBlockHeader.payloadHash)
+        assertEquals(456L, flowBlockHeader.view)
+        assertArrayEquals(voterSigDataBytes, flowBlockHeader.parentVoterSigData)
+        assertEquals(FlowId.of(proposerIdBytes), flowBlockHeader.proposerId)
+        assertArrayEquals(proposerSigDataBytes, flowBlockHeader.proposerSigData)
+        assertEquals(FlowChainId.of(chainId), flowBlockHeader.chainId)
+        assertArrayEquals(voterIndicesBytes, flowBlockHeader.parentVoterIndices)
+        assertEquals(789L, flowBlockHeader.parentView)
+    }
+
+    @Test
+    fun `test builder() method`() {
+        // mock FlowQuorumCertificate
+        val view = 123L
+        val blockIdBytes = ByteArray(32) { 0x01 }
+        val signerIndicesBytes = ByteArray(32) { 0x02 }
+        val sigDataBytes = ByteArray(32) { 0x03 }
+
+        val grpcQuorumCertificate = mock(BlockHeaderOuterClass.QuorumCertificate::class.java)
+        `when`(grpcQuorumCertificate.view).thenReturn(view)
+        `when`(grpcQuorumCertificate.blockId).thenReturn(ByteString.copyFrom(blockIdBytes))
+        `when`(grpcQuorumCertificate.signerIndices).thenReturn(ByteString.copyFrom(signerIndicesBytes))
+        `when`(grpcQuorumCertificate.sigData).thenReturn(ByteString.copyFrom(sigDataBytes))
+
+        val flowQuorumCertificate = FlowQuorumCertificate.of(grpcQuorumCertificate)
+
+        // mock FlowTimeoutCertificate
+        val highQcViews = listOf(1L, 2L)
+        val signerIndices = byteArrayOf(1, 2)
+        val sigData = byteArrayOf(3, 4)
+
+        val timeoutCertificate = FlowTimeoutCertificate(
+            view = view,
+            highQcViews = highQcViews,
+            highestQc = flowQuorumCertificate,
+            signerIndices = signerIndices,
+            sigData = sigData
+        )
+
+        // Create FlowBlockHeader
+        val flowBlockHeader = FlowBlockHeader(
+            id = id,
+            parentId = parentId,
+            height = 123L,
+            timestamp = timestamp,
+            payloadHash = payloadHashBytes,
+            view = 456L,
+            parentVoterSigData = voterSigDataBytes,
+            proposerId = proposerId,
+            proposerSigData = proposerSigDataBytes,
+            chainId = chainId,
+            parentVoterIndices = voterIndicesBytes,
+            lastViewTc = timeoutCertificate,
+            parentView = 789L
+        )
+
+        val result = flowBlockHeader.builder().build()
+
+        assertEquals(id.byteStringValue, result.id)
+        assertEquals(parentId.byteStringValue, result.parentId)
+        assertEquals(123L, result.height)
+        assertEquals(timestamp.asTimestamp(), result.timestamp)
+        assertEquals(UnsafeByteOperations.unsafeWrap(payloadHashBytes), result.payloadHash)
+        assertEquals(456L, result.view)
+        assertEquals(UnsafeByteOperations.unsafeWrap(voterSigDataBytes), result.parentVoterSigData)
+        assertEquals(proposerId.byteStringValue, result.proposerId)
+        assertEquals(UnsafeByteOperations.unsafeWrap(proposerSigDataBytes), result.proposerSigData)
+        assertEquals(chainId.id, result.chainId)
+        assertEquals(UnsafeByteOperations.unsafeWrap(voterIndicesBytes), result.parentVoterIndices)
+        assertEquals(789L, result.parentView)
+    }
+
+    @Test
+    fun `test equals() method`() {
+        val flowBlockHeader1 = FlowBlockHeader(
+            id = id,
+            parentId = parentId,
+            height = 123L,
+            timestamp = timestamp,
+            payloadHash = payloadHashBytes,
+            view = 456L,
+            parentVoterSigData = voterSigDataBytes,
+            proposerId = proposerId,
+            proposerSigData = proposerSigDataBytes,
+            chainId = chainId,
+            parentVoterIndices = voterIndicesBytes,
+            lastViewTc = timeoutCertificate,
+            parentView = 789L
+        )
+
+        val flowBlockHeader2 = FlowBlockHeader(
+            id = id,
+            parentId = parentId,
+            height = 123L,
+            timestamp = timestamp,
+            payloadHash = payloadHashBytes,
+            view = 456L,
+            parentVoterSigData = voterSigDataBytes,
+            proposerId = proposerId,
+            proposerSigData = proposerSigDataBytes,
+            chainId = chainId,
+            parentVoterIndices = voterIndicesBytes,
+            lastViewTc = timeoutCertificate,
+            parentView = 789L
+        )
+
+        assertEquals(flowBlockHeader1, flowBlockHeader2)
+
+        val flowBlockHeader3 = FlowBlockHeader(
+            id = FlowId.of(ByteArray(32) { 0x08 }),
+            parentId = parentId,
+            height = 124L,
+            timestamp = timestamp.plusDays(1),
+            payloadHash = ByteArray(32) { 0x09 },
+            view = 789L,
+            parentVoterSigData = voterSigDataBytes,
+            proposerId = proposerId,
+            proposerSigData = proposerSigDataBytes,
+            chainId = chainId,
+            parentVoterIndices = voterIndicesBytes,
+            lastViewTc = timeoutCertificate,
+            parentView = 100L
+        )
+
+        assertNotEquals(flowBlockHeader1, flowBlockHeader3)
+    }
+
+    @Test
+    fun `test hashCode() method`() {
+        val flowBlockHeader1 = FlowBlockHeader(
+            id = id,
+            parentId = parentId,
+            height = 123L,
+            timestamp = timestamp,
+            payloadHash = payloadHashBytes,
+            view = 456L,
+            parentVoterSigData = voterSigDataBytes,
+            proposerId = proposerId,
+            proposerSigData = proposerSigDataBytes,
+            chainId = chainId,
+            parentVoterIndices = voterIndicesBytes,
+            lastViewTc = timeoutCertificate,
+            parentView = 789L
+        )
+
+        val flowBlockHeader2 = FlowBlockHeader(
+            id = id,
+            parentId = parentId,
+            height = 123L,
+            timestamp = timestamp,
+            payloadHash = payloadHashBytes,
+            view = 456L,
+            parentVoterSigData = voterSigDataBytes,
+            proposerId = proposerId,
+            proposerSigData = proposerSigDataBytes,
+            chainId = chainId,
+            parentVoterIndices = voterIndicesBytes,
+            lastViewTc = timeoutCertificate,
+            parentView = 789L
+        )
+
+        assertEquals(flowBlockHeader1.hashCode(), flowBlockHeader2.hashCode())
+
+        val flowBlockHeader3 = FlowBlockHeader(
+            id = FlowId.of(ByteArray(32) { 0x08 }),
+            parentId = parentId,
+            height = 124L,
+            timestamp = timestamp.plusDays(1),
+            payloadHash = ByteArray(32) { 0x09 },
+            view = 789L,
+            parentVoterSigData = voterSigDataBytes,
+            proposerId = proposerId,
+            proposerSigData = proposerSigDataBytes,
+            chainId = chainId,
+            parentVoterIndices = voterIndicesBytes,
+            lastViewTc = timeoutCertificate,
+            parentView = 100L
+        )
+
+        assertNotEquals(flowBlockHeader1.hashCode(), flowBlockHeader3.hashCode())
+    }
 }

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockHeaderTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockHeaderTest.kt
@@ -76,7 +76,7 @@ class FlowBlockHeaderTest {
 
     @Test
     fun `test builder() method`() {
-        // mock FlowQuorumCertificate
+        // Mock FlowQuorumCertificate
         val view = 123L
         val blockIdBytes = ByteArray(32) { 0x01 }
         val signerIndicesBytes = ByteArray(32) { 0x02 }
@@ -90,7 +90,7 @@ class FlowBlockHeaderTest {
 
         val flowQuorumCertificate = FlowQuorumCertificate.of(grpcQuorumCertificate)
 
-        // mock FlowTimeoutCertificate
+        // Mock FlowTimeoutCertificate
         val highQcViews = listOf(1L, 2L)
         val signerIndices = byteArrayOf(1, 2)
         val sigData = byteArrayOf(3, 4)
@@ -103,7 +103,6 @@ class FlowBlockHeaderTest {
             sigData = sigData
         )
 
-        // Create FlowBlockHeader
         val flowBlockHeader = FlowBlockHeader(
             id = id,
             parentId = parentId,

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockHeaderTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockHeaderTest.kt
@@ -23,8 +23,8 @@ class FlowBlockHeaderTest {
         val parentId = FlowId.of(parentIdBytes)
         val proposerId = FlowId.of(proposerIdBytes)
         val chainId = FlowChainId.of("mainnet")
-        val timestamp = LocalDateTime.now()
-        val timeoutCertificate = mock(FlowTimeoutCertificate::class.java)
+        val timestamp: LocalDateTime = LocalDateTime.now()
+        val timeoutCertificate: FlowTimeoutCertificate = mock(FlowTimeoutCertificate::class.java)
     }
     @Test
     fun `test of() method`() {

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockHeaderTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockHeaderTest.kt
@@ -1,0 +1,4 @@
+package org.onflow.flow.sdk.models
+
+class FlowBlockHeaderTest {
+}

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockTest.kt
@@ -24,11 +24,12 @@ class FlowBlockTest {
             .setTimestamp(timestamp)
             .setBlockHeader(
                 BlockHeaderOuterClass.BlockHeader.newBuilder()
-                .setId(ByteString.copyFromUtf8("header_id"))
-                .setParentId(ByteString.copyFromUtf8("header_parent_id"))
-                .setHeight(124)
-                .setTimestamp(timestamp)
-                .build())
+                    .setId(ByteString.copyFromUtf8("header_id"))
+                    .setParentId(ByteString.copyFromUtf8("header_parent_id"))
+                    .setHeight(124)
+                    .setTimestamp(timestamp)
+                    .build()
+            )
             .setProtocolStateId(ByteString.copyFromUtf8("protocol_state_id"))
 
         val flowBlock = FlowBlock.of(blockBuilder.build())
@@ -91,7 +92,7 @@ class FlowBlockTest {
         assert(blockBuilder.id.toByteArray().contentEquals(fixedSize("id".toByteArray(), 32)))
         assert(blockBuilder.parentId.toByteArray().contentEquals(fixedSize("parent_id".toByteArray(), 32)))
         assert(blockBuilder.height == 123L)
-        assert(blockBuilder.timestamp == flowBlock.timestamp.asTimestamp())
+        assert(blockBuilder.timestamp.equals(flowBlock.timestamp.asTimestamp()))
         assert(blockBuilder.collectionGuaranteesList.isEmpty())
         assert(blockBuilder.blockSealsList.isEmpty())
         assert(blockBuilder.signaturesList.isEmpty())
@@ -99,4 +100,3 @@ class FlowBlockTest {
         assert(blockBuilder.protocolStateId.toByteArray().contentEquals(fixedSize("protocol_state_id".toByteArray(), 32)))
     }
 }
-

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowBlockTest.kt
@@ -2,12 +2,10 @@ package org.onflow.flow.sdk.models
 
 import com.google.protobuf.ByteString
 import com.google.protobuf.Timestamp
-import org.onflow.flow.sdk.FlowBlock
-import org.onflow.flow.sdk.FlowId
-import org.onflow.flow.sdk.asTimestamp
-import org.onflow.flow.sdk.fixedSize
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.onflow.flow.sdk.*
+import org.onflow.protobuf.entities.BlockHeaderOuterClass
 import org.onflow.protobuf.entities.BlockOuterClass
 import java.time.Instant
 import java.time.LocalDateTime
@@ -24,6 +22,14 @@ class FlowBlockTest {
             .setParentId(ByteString.copyFromUtf8("parent_id"))
             .setHeight(123)
             .setTimestamp(timestamp)
+            .setBlockHeader(
+                BlockHeaderOuterClass.BlockHeader.newBuilder()
+                .setId(ByteString.copyFromUtf8("header_id"))
+                .setParentId(ByteString.copyFromUtf8("header_parent_id"))
+                .setHeight(124)
+                .setTimestamp(timestamp)
+                .build())
+            .setProtocolStateId(ByteString.copyFromUtf8("protocol_state_id"))
 
         val flowBlock = FlowBlock.of(blockBuilder.build())
 
@@ -40,13 +46,14 @@ class FlowBlockTest {
         assert(flowBlock.id.bytes.contentEquals(fixedSize("id".toByteArray(), 32)))
         assert(flowBlock.parentId.bytes.contentEquals(fixedSize("parent_id".toByteArray(), 32)))
         assertEquals(flowBlock.height, 123L)
-        assertEquals(
-            expectedUtcDateTime,
-            actualUtcDateTime,
-        )
+        assertEquals(expectedUtcDateTime, actualUtcDateTime)
         assert(flowBlock.collectionGuarantees.isEmpty())
         assert(flowBlock.blockSeals.isEmpty())
         assert(flowBlock.signatures.isEmpty())
+        assert(flowBlock.executionReceiptMetaList.isEmpty())
+        assert(flowBlock.executionResultList.isEmpty())
+        assert(flowBlock.blockHeader.id.bytes.contentEquals(fixedSize("header_id".toByteArray(), 32)))
+        assert(flowBlock.protocolStateId.bytes.contentEquals(fixedSize("protocol_state_id".toByteArray(), 32)))
     }
 
     @Test
@@ -58,7 +65,25 @@ class FlowBlockTest {
             timestamp = LocalDateTime.now(),
             collectionGuarantees = emptyList(),
             blockSeals = emptyList(),
-            signatures = emptyList()
+            signatures = emptyList(),
+            executionReceiptMetaList = emptyList(),
+            executionResultList = emptyList(),
+            blockHeader = FlowBlockHeader(
+                id = FlowId.of("header_id".toByteArray()),
+                parentId = FlowId.of("header_parent_id".toByteArray()),
+                height = 124,
+                timestamp = LocalDateTime.now(),
+                payloadHash = ByteArray(32),
+                view = 1,
+                parentVoterSigData = ByteArray(32),
+                proposerId = FlowId.of("proposer_id".toByteArray()),
+                proposerSigData = ByteArray(32),
+                chainId = FlowChainId.MAINNET,
+                parentVoterIndices = ByteArray(32),
+                lastViewTc = FlowTimeoutCertificate(1L, emptyList(), FlowQuorumCertificate(1L, FlowId.of("block_id".toByteArray()), ByteArray(32), ByteArray(32)), ByteArray(32), ByteArray(32)),
+                parentView = 1
+            ),
+            protocolStateId = FlowId.of("protocol_state_id".toByteArray())
         )
 
         val blockBuilder = flowBlock.builder()
@@ -70,5 +95,8 @@ class FlowBlockTest {
         assert(blockBuilder.collectionGuaranteesList.isEmpty())
         assert(blockBuilder.blockSealsList.isEmpty())
         assert(blockBuilder.signaturesList.isEmpty())
+        assert(blockBuilder.blockHeader.id.toByteArray().contentEquals(fixedSize("header_id".toByteArray(), 32)))
+        assert(blockBuilder.protocolStateId.toByteArray().contentEquals(fixedSize("protocol_state_id".toByteArray(), 32)))
     }
 }
+

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowChunkTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowChunkTest.kt
@@ -200,4 +200,3 @@ class FlowChunkTest {
         assertNotEquals(flowChunk1.hashCode(), flowChunk3.hashCode())
     }
 }
-

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowChunkTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowChunkTest.kt
@@ -1,0 +1,4 @@
+package org.onflow.flow.sdk.models
+
+class FlowChunkTest {
+}

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowChunkTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowChunkTest.kt
@@ -1,4 +1,203 @@
 package org.onflow.flow.sdk.models
 
+import com.google.protobuf.ByteString
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.onflow.flow.sdk.FlowChunk
+import org.onflow.flow.sdk.FlowId
+import org.onflow.protobuf.entities.ExecutionResultOuterClass
+
 class FlowChunkTest {
+    @Test
+    fun `test of() method`() {
+        val collectionIndex = 1
+        val startStateBytes = ByteArray(32) { 0x01 }
+        val eventCollectionBytes = ByteArray(32) { 0x02 }
+        val blockIdBytes = ByteArray(32) { 0x03 }
+        val totalComputationUsed = 1000L
+        val numberOfTransactions = 10
+        val index = 5L
+        val endStateBytes = ByteArray(32) { 0x04 }
+        val executionDataIdBytes = ByteArray(32) { 0x05 }
+        val stateDeltaCommitmentBytes = ByteArray(32) { 0x06 }
+
+        val grpcChunk = mock(ExecutionResultOuterClass.Chunk::class.java)
+        `when`(grpcChunk.collectionIndex).thenReturn(collectionIndex)
+        `when`(grpcChunk.startState).thenReturn(ByteString.copyFrom(startStateBytes))
+        `when`(grpcChunk.eventCollection).thenReturn(ByteString.copyFrom(eventCollectionBytes))
+        `when`(grpcChunk.blockId).thenReturn(ByteString.copyFrom(blockIdBytes))
+        `when`(grpcChunk.totalComputationUsed).thenReturn(totalComputationUsed)
+        `when`(grpcChunk.numberOfTransactions).thenReturn(numberOfTransactions)
+        `when`(grpcChunk.index).thenReturn(index)
+        `when`(grpcChunk.endState).thenReturn(ByteString.copyFrom(endStateBytes))
+        `when`(grpcChunk.executionDataId).thenReturn(ByteString.copyFrom(executionDataIdBytes))
+        `when`(grpcChunk.stateDeltaCommitment).thenReturn(ByteString.copyFrom(stateDeltaCommitmentBytes))
+
+        val flowChunk = FlowChunk.of(grpcChunk)
+
+        assertEquals(collectionIndex, flowChunk.collectionIndex)
+        assertArrayEquals(startStateBytes, flowChunk.startState)
+        assertArrayEquals(eventCollectionBytes, flowChunk.eventCollection)
+        assertEquals(FlowId.of(blockIdBytes), flowChunk.blockId)
+        assertEquals(totalComputationUsed, flowChunk.totalComputationUsed)
+        assertEquals(numberOfTransactions, flowChunk.numberOfTransactions)
+        assertEquals(index, flowChunk.index)
+        assertArrayEquals(endStateBytes, flowChunk.endState)
+        assertEquals(FlowId.of(executionDataIdBytes), flowChunk.executionDataId)
+        assertArrayEquals(stateDeltaCommitmentBytes, flowChunk.stateDeltaCommitment)
+    }
+
+    @Test
+    fun `test builder() method`() {
+        val collectionIndex = 1
+        val startStateBytes = ByteArray(32) { 0x01 }
+        val eventCollectionBytes = ByteArray(32) { 0x02 }
+        val blockId = FlowId.of(ByteArray(32) { 0x03 })
+        val totalComputationUsed = 1000L
+        val numberOfTransactions = 10
+        val index = 5L
+        val endStateBytes = ByteArray(32) { 0x04 }
+        val executionDataId = FlowId.of(ByteArray(32) { 0x05 })
+        val stateDeltaCommitmentBytes = ByteArray(32) { 0x06 }
+
+        val flowChunk = FlowChunk(
+            collectionIndex = collectionIndex,
+            startState = startStateBytes,
+            eventCollection = eventCollectionBytes,
+            blockId = blockId,
+            totalComputationUsed = totalComputationUsed,
+            numberOfTransactions = numberOfTransactions,
+            index = index,
+            endState = endStateBytes,
+            executionDataId = executionDataId,
+            stateDeltaCommitment = stateDeltaCommitmentBytes
+        )
+
+        val result = flowChunk.builder().build()
+
+        assertEquals(collectionIndex, result.collectionIndex)
+        assertEquals(ByteString.copyFrom(startStateBytes), result.startState)
+        assertEquals(ByteString.copyFrom(eventCollectionBytes), result.eventCollection)
+        assertEquals(blockId.byteStringValue, result.blockId)
+        assertEquals(totalComputationUsed, result.totalComputationUsed)
+        assertEquals(numberOfTransactions, result.numberOfTransactions)
+        assertEquals(index, result.index)
+        assertEquals(ByteString.copyFrom(endStateBytes), result.endState)
+        assertEquals(executionDataId.byteStringValue, result.executionDataId)
+        assertEquals(ByteString.copyFrom(stateDeltaCommitmentBytes), result.stateDeltaCommitment)
+    }
+
+    @Test
+    fun `test equals() method`() {
+        val collectionIndex1 = 1
+        val collectionIndex2 = 2
+        val startState1 = ByteArray(32) { 0x01 }
+        val startState2 = ByteArray(32) { 0x02 }
+        val blockId1 = FlowId.of(ByteArray(32) { 0x03 })
+        val blockId2 = FlowId.of(ByteArray(32) { 0x04 })
+        val totalComputationUsed1 = 1000L
+        val totalComputationUsed2 = 2000L
+        val endState1 = ByteArray(32) { 0x04 }
+        val endState2 = ByteArray(32) { 0x05 }
+
+        val flowChunk1 = FlowChunk(
+            collectionIndex = collectionIndex1,
+            startState = startState1,
+            eventCollection = startState1,
+            blockId = blockId1,
+            totalComputationUsed = totalComputationUsed1,
+            numberOfTransactions = 10,
+            index = 5L,
+            endState = endState1,
+            executionDataId = blockId1,
+            stateDeltaCommitment = startState1
+        )
+
+        val flowChunk2 = FlowChunk(
+            collectionIndex = collectionIndex1,
+            startState = startState1,
+            eventCollection = startState1,
+            blockId = blockId1,
+            totalComputationUsed = totalComputationUsed1,
+            numberOfTransactions = 10,
+            index = 5L,
+            endState = endState1,
+            executionDataId = blockId1,
+            stateDeltaCommitment = startState1
+        )
+
+        val flowChunk3 = FlowChunk(
+            collectionIndex = collectionIndex2,
+            startState = startState2,
+            eventCollection = startState2,
+            blockId = blockId2,
+            totalComputationUsed = totalComputationUsed2,
+            numberOfTransactions = 20,
+            index = 10L,
+            endState = endState2,
+            executionDataId = blockId2,
+            stateDeltaCommitment = startState2
+        )
+
+        assertEquals(flowChunk1, flowChunk2)
+        assertNotEquals(flowChunk1, flowChunk3)
+    }
+
+    @Test
+    fun `test hashCode() method`() {
+        val collectionIndex1 = 1
+        val collectionIndex2 = 2
+        val startState1 = ByteArray(32) { 0x01 }
+        val startState2 = ByteArray(32) { 0x02 }
+        val blockId1 = FlowId.of(ByteArray(32) { 0x03 })
+        val blockId2 = FlowId.of(ByteArray(32) { 0x04 })
+        val totalComputationUsed1 = 1000L
+        val totalComputationUsed2 = 2000L
+        val endState1 = ByteArray(32) { 0x04 }
+        val endState2 = ByteArray(32) { 0x05 }
+
+        val flowChunk1 = FlowChunk(
+            collectionIndex = collectionIndex1,
+            startState = startState1,
+            eventCollection = startState1,
+            blockId = blockId1,
+            totalComputationUsed = totalComputationUsed1,
+            numberOfTransactions = 10,
+            index = 5L,
+            endState = endState1,
+            executionDataId = blockId1,
+            stateDeltaCommitment = startState1
+        )
+
+        val flowChunk2 = FlowChunk(
+            collectionIndex = collectionIndex1,
+            startState = startState1,
+            eventCollection = startState1,
+            blockId = blockId1,
+            totalComputationUsed = totalComputationUsed1,
+            numberOfTransactions = 10,
+            index = 5L,
+            endState = endState1,
+            executionDataId = blockId1,
+            stateDeltaCommitment = startState1
+        )
+
+        val flowChunk3 = FlowChunk(
+            collectionIndex = collectionIndex2,
+            startState = startState2,
+            eventCollection = startState2,
+            blockId = blockId2,
+            totalComputationUsed = totalComputationUsed2,
+            numberOfTransactions = 20,
+            index = 10L,
+            endState = endState2,
+            executionDataId = blockId2,
+            stateDeltaCommitment = startState2
+        )
+
+        assertEquals(flowChunk1.hashCode(), flowChunk2.hashCode())
+        assertNotEquals(flowChunk1.hashCode(), flowChunk3.hashCode())
+    }
 }
+

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowCollectionGuaranteeTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowCollectionGuaranteeTest.kt
@@ -7,18 +7,26 @@ import org.onflow.flow.sdk.FlowSignature
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.onflow.protobuf.entities.CollectionOuterClass
+import com.google.protobuf.UnsafeByteOperations
 
 class FlowCollectionGuaranteeTest {
+
     @Test
     fun `Test building FlowCollectionGuarantee from CollectionOuterClass`() {
         val collectionIdBytes = byteArrayOf(1, 2, 3)
+        val referenceBlockIdBytes = byteArrayOf(10, 11, 12)
+        val signatureBytes = byteArrayOf(13, 14, 15)
         val signature1Bytes = byteArrayOf(4, 5, 6)
         val signature2Bytes = byteArrayOf(7, 8, 9)
+        val signerIndicesBytes = byteArrayOf(16, 17)
 
         val collectionGuaranteeBuilder = CollectionOuterClass.CollectionGuarantee.newBuilder()
             .setCollectionId(ByteString.copyFrom(collectionIdBytes))
             .addSignatures(ByteString.copyFrom(signature1Bytes))
             .addSignatures(ByteString.copyFrom(signature2Bytes))
+            .setReferenceBlockId(ByteString.copyFrom(referenceBlockIdBytes))
+            .setSignature(ByteString.copyFrom(signatureBytes))
+            .setSignerIndices(UnsafeByteOperations.unsafeWrap(signerIndicesBytes))
 
         val flowCollectionGuarantee = FlowCollectionGuarantee.of(collectionGuaranteeBuilder.build())
 
@@ -26,14 +34,20 @@ class FlowCollectionGuaranteeTest {
         assertEquals(2, flowCollectionGuarantee.signatures.size)
         assertEquals(FlowSignature(signature1Bytes), flowCollectionGuarantee.signatures[0])
         assertEquals(FlowSignature(signature2Bytes), flowCollectionGuarantee.signatures[1])
+        assertEquals(FlowId.of(referenceBlockIdBytes), flowCollectionGuarantee.referenceBlockId)
+        assertEquals(FlowSignature(signatureBytes), flowCollectionGuarantee.signature)
+        assertEquals(signerIndicesBytes.toList(), flowCollectionGuarantee.signerIndices.toList())
     }
 
     @Test
     fun `Test building CollectionOuterClass from FlowCollectionGuarantee`() {
         val collectionId = FlowId.of(byteArrayOf(1, 2, 3))
+        val referenceBlockId = FlowId.of(byteArrayOf(10, 11, 12))
+        val signature = FlowSignature(byteArrayOf(13, 14, 15))
         val signatures = listOf(FlowSignature(byteArrayOf(4, 5, 6)), FlowSignature(byteArrayOf(7, 8, 9)))
+        val signerIndices = byteArrayOf(16, 17)
 
-        val flowCollectionGuarantee = FlowCollectionGuarantee(collectionId, signatures)
+        val flowCollectionGuarantee = FlowCollectionGuarantee(collectionId, signatures, referenceBlockId, signature, signerIndices)
 
         val collectionGuaranteeBuilder = flowCollectionGuarantee.builder()
         val collectionGuarantee = collectionGuaranteeBuilder.build()
@@ -42,5 +56,8 @@ class FlowCollectionGuaranteeTest {
         assertEquals(2, collectionGuarantee.signaturesCount)
         assertEquals(ByteString.copyFrom(signatures[0].bytes), collectionGuarantee.getSignatures(0))
         assertEquals(ByteString.copyFrom(signatures[1].bytes), collectionGuarantee.getSignatures(1))
+        assertEquals(ByteString.copyFrom(referenceBlockId.bytes), collectionGuarantee.referenceBlockId)
+        assertEquals(ByteString.copyFrom(signature.bytes), collectionGuarantee.signature)
+        assertEquals(ByteString.copyFrom(signerIndices), collectionGuarantee.signerIndices)
     }
 }

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowCollectionGuaranteeTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowCollectionGuaranteeTest.kt
@@ -10,7 +10,6 @@ import org.onflow.protobuf.entities.CollectionOuterClass
 import com.google.protobuf.UnsafeByteOperations
 
 class FlowCollectionGuaranteeTest {
-
     @Test
     fun `Test building FlowCollectionGuarantee from CollectionOuterClass`() {
         val collectionIdBytes = byteArrayOf(1, 2, 3)

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionReceiptMetaTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionReceiptMetaTest.kt
@@ -1,4 +1,92 @@
 package org.onflow.flow.sdk.models
 
+import com.google.protobuf.ByteString
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.onflow.flow.sdk.FlowExecutionReceiptMeta
+import org.onflow.flow.sdk.FlowId
+import org.onflow.flow.sdk.FlowSignature
+import org.onflow.protobuf.entities.ExecutionResultOuterClass
+
 class FlowExecutionReceiptMetaTest {
+    @Test
+    fun `test of() method`() {
+        val executorIdBytes = ByteArray(32) { 0x01 }
+        val resultIdBytes = ByteArray(32) { 0x02 }
+        val spocksBytes = listOf(ByteArray(32) { 0x03 }, ByteArray(32) { 0x04 })
+        val executorSignatureBytes = ByteArray(32) { 0x05 }
+
+        val grpcMeta = mock(ExecutionResultOuterClass.ExecutionReceiptMeta::class.java)
+        `when`(grpcMeta.executorId).thenReturn(ByteString.copyFrom(executorIdBytes))
+        `when`(grpcMeta.resultId).thenReturn(ByteString.copyFrom(resultIdBytes))
+        `when`(grpcMeta.spocksList).thenReturn(spocksBytes.map { ByteString.copyFrom(it) })
+        `when`(grpcMeta.executorSignature).thenReturn(ByteString.copyFrom(executorSignatureBytes))
+
+        val flowMeta = FlowExecutionReceiptMeta.of(grpcMeta)
+
+        assertEquals(FlowId.of(executorIdBytes), flowMeta.executorId)
+        assertEquals(FlowId.of(resultIdBytes), flowMeta.resultId)
+        assertArrayEquals(spocksBytes[0], flowMeta.spocks[0])
+        assertArrayEquals(spocksBytes[1], flowMeta.spocks[1])
+        assertEquals(FlowSignature(executorSignatureBytes), flowMeta.executorSignature)
+    }
+
+    @Test
+    fun `test builder() method`() {
+        val executorId = FlowId.of(ByteArray(32) { 0x01 })
+        val resultId = FlowId.of(ByteArray(32) { 0x02 })
+        val spocks = listOf(ByteArray(32) { 0x03 }, ByteArray(32) { 0x04 })
+        val executorSignature = FlowSignature(ByteArray(32) { 0x05 })
+
+        val flowMeta = FlowExecutionReceiptMeta(executorId, resultId, spocks, executorSignature)
+        val result = flowMeta.builder().build()
+
+        assertEquals(executorId.byteStringValue, result.executorId)
+        assertEquals(resultId.byteStringValue, result.resultId)
+        assertEquals(spocks.size, result.spocksCount)
+        assertEquals(ByteString.copyFrom(spocks[0]), result.spocksList[0])
+        assertEquals(ByteString.copyFrom(spocks[1]), result.spocksList[1])
+        assertEquals(executorSignature.byteStringValue, result.executorSignature)
+    }
+
+    @Test
+    fun `test equals() method`() {
+        val executorId1 = FlowId.of(ByteArray(32) { 0x01 })
+        val resultId1 = FlowId.of(ByteArray(32) { 0x02 })
+        val spocks1 = listOf(ByteArray(32) { 0x03 })
+        val executorSignature1 = FlowSignature(ByteArray(32) { 0x04 })
+
+        val executorId2 = FlowId.of(ByteArray(32) { 0x05 })
+        val resultId2 = FlowId.of(ByteArray(32) { 0x06 })
+        val spocks2 = listOf(ByteArray(32) { 0x07 })
+        val executorSignature2 = FlowSignature(ByteArray(32) { 0x08 })
+
+        val meta1 = FlowExecutionReceiptMeta(executorId1, resultId1, spocks1, executorSignature1)
+        val meta2 = FlowExecutionReceiptMeta(executorId1, resultId1, spocks1, executorSignature1)
+        val meta3 = FlowExecutionReceiptMeta(executorId2, resultId2, spocks2, executorSignature2)
+
+        assertEquals(meta1, meta2)
+        assertNotEquals(meta1, meta3)
+    }
+
+    @Test
+    fun `test hashCode() method`() {
+        val executorId1 = FlowId.of(ByteArray(32) { 0x01 })
+        val resultId1 = FlowId.of(ByteArray(32) { 0x02 })
+        val spocks1 = listOf(ByteArray(32) { 0x03 })
+        val executorSignature1 = FlowSignature(ByteArray(32) { 0x04 })
+
+        val executorId2 = FlowId.of(ByteArray(32) { 0x05 })
+        val resultId2 = FlowId.of(ByteArray(32) { 0x06 })
+        val spocks2 = listOf(ByteArray(32) { 0x07 })
+        val executorSignature2 = FlowSignature(ByteArray(32) { 0x08 })
+
+        val meta1 = FlowExecutionReceiptMeta(executorId1, resultId1, spocks1, executorSignature1)
+        val meta2 = FlowExecutionReceiptMeta(executorId1, resultId1, spocks1, executorSignature1)
+        val meta3 = FlowExecutionReceiptMeta(executorId2, resultId2, spocks2, executorSignature2)
+
+        assertEquals(meta1.hashCode(), meta2.hashCode())
+        assertNotEquals(meta1.hashCode(), meta3.hashCode())
+    }
 }

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionReceiptMetaTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionReceiptMetaTest.kt
@@ -1,0 +1,4 @@
+package org.onflow.flow.sdk.models
+
+class FlowExecutionReceiptMetaTest {
+}

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionResultTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionResultTest.kt
@@ -1,0 +1,4 @@
+package org.onflow.flow.sdk.models
+
+class FlowExecutionResultTest {
+}

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionResultTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionResultTest.kt
@@ -49,7 +49,7 @@ class FlowExecutionResultTest {
 
         // Mock service event
         val serviceEvent = mock(ExecutionResultOuterClass.ServiceEvent::class.java)
-        `when`(serviceEvent.type).thenReturn("EventType")  // Mock the getType() method
+        `when`(serviceEvent.type).thenReturn("EventType")
         `when`(serviceEvent.payload).thenReturn(ByteString.copyFrom(payloadBytes))
         `when`(grpcExecutionResultInner.serviceEventsList).thenReturn(listOf(serviceEvent))
 
@@ -84,8 +84,8 @@ class FlowExecutionResultTest {
 
         // Mock service event
         val serviceEvent = mock(ExecutionResultOuterClass.ServiceEvent::class.java)
-        `when`(serviceEvent.type).thenReturn("EventType")  // Mock the getType() method
-        `when`(serviceEvent.payload).thenReturn(ByteString.copyFrom(payloadBytes))  // Mock the getPayload() method
+        `when`(serviceEvent.type).thenReturn("EventType")
+        `when`(serviceEvent.payload).thenReturn(ByteString.copyFrom(payloadBytes))
 
         // Mock ExecutionResult
         val grpcExecutionResult = mock(ExecutionResultOuterClass.ExecutionResult::class.java)
@@ -100,59 +100,42 @@ class FlowExecutionResultTest {
         assertEquals(FlowId.of(previousResultIdBytes), flowExecutionResult.previousResultId)
         assertEquals(1, flowExecutionResult.chunks.size)
         assertEquals(1, flowExecutionResult.serviceEvents.size)
-        assertEquals("EventType", flowExecutionResult.serviceEvents[0].type)  // Validate the service event type
-        assertArrayEquals(payloadBytes, flowExecutionResult.serviceEvents[0].payload)  // Validate the service event payload
+        assertEquals("EventType", flowExecutionResult.serviceEvents[0].type)
+        assertArrayEquals(payloadBytes, flowExecutionResult.serviceEvents[0].payload)
     }
 
     @Test
     fun `test builder() method`() {
-        val blockIdBytes = ByteArray(32) { 0x01 }
-        val previousResultIdBytes = ByteArray(32) { 0x02 }
-        val blockId = FlowId.of(blockIdBytes)
-        val previousResultId = FlowId.of(previousResultIdBytes)
+        // Setup mock FlowServiceEvent
+        val serviceEvent = FlowServiceEvent("EventType", blockIdBytes)
 
-        // Mock FlowChunk and its builder
-        val chunk = mock(FlowChunk::class.java)
-        val chunkBuilder = mock(ExecutionResultOuterClass.Chunk.Builder::class.java)
+        // Setup mock FlowChunk
+        val flowChunk = FlowChunk(
+            collectionIndex = collectionIndex,
+            startState = startStateBytes,
+            eventCollection = eventCollectionBytes,
+            blockId = FlowId.of(blockIdBytes),
+            totalComputationUsed = totalComputationUsed,
+            numberOfTransactions = numberOfTransactions,
+            index = index,
+            endState = endStateBytes,
+            executionDataId = FlowId.of(blockIdBytes),
+            stateDeltaCommitment = stateDeltaCommitmentBytes
+        )
 
-        // Set up the behavior for the builder methods
-        `when`(chunk.builder()).thenReturn(chunkBuilder)
-        `when`(chunkBuilder.build()).thenReturn(ExecutionResultOuterClass.Chunk.newBuilder()
-            .setCollectionIndex(1)
-            .setBlockId(ByteString.copyFrom(blockIdBytes))
-            .build())  // Return a valid Chunk object with required fields
-
-        // Mock FlowServiceEvent and its builder
-        val serviceEvent = mock(FlowServiceEvent::class.java)
-        val serviceEventBuilder = mock(ExecutionResultOuterClass.ServiceEvent.Builder::class.java)
-
-        // Set up the behavior for the service event builder
-        `when`(serviceEvent.builder()).thenReturn(serviceEventBuilder)
-        `when`(serviceEventBuilder.build()).thenReturn(ExecutionResultOuterClass.ServiceEvent.newBuilder()
-            .setType("EventType")
-            .setPayload(ByteString.copyFrom(ByteArray(32) { 0x07 }))  // Use any valid ByteString payload
-            .build())  // Ensure this returns a valid built object
-
-        // Create FlowExecutionResult instance with mocks
         val flowExecutionResult = FlowExecutionResult(
-            blockId = blockId,
-            previousResultId = previousResultId,
-            chunks = listOf(chunk),
+            blockId = FlowId.of(blockIdBytes),
+            previousResultId = FlowId.of(previousResultIdBytes),
+            chunks = listOf(flowChunk),
             serviceEvents = listOf(serviceEvent)
         )
 
-        // Call the builder() method and build the result
         val result = flowExecutionResult.builder().build()
 
-        // Assertions to verify the builder results
-        assertEquals(blockId.byteStringValue, result.blockId)
-        assertEquals(previousResultId.byteStringValue, result.previousResultId)
+        assertEquals(FlowId.of(blockIdBytes).byteStringValue, result.blockId)
+        assertEquals(FlowId.of(previousResultIdBytes).byteStringValue, result.previousResultId)
         assertEquals(1, result.chunksCount)
         assertEquals(1, result.serviceEventsCount)
-
-        // Verify that the builders for the chunks and service events were invoked
-        verify(chunk).builder()
-        verify(serviceEvent).builder()
     }
 
     @Test

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionResultTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionResultTest.kt
@@ -1,4 +1,231 @@
 package org.onflow.flow.sdk.models
 
+import com.google.protobuf.ByteString
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.onflow.flow.sdk.*
+import org.onflow.protobuf.access.Access
+import org.onflow.protobuf.entities.ExecutionResultOuterClass
+
 class FlowExecutionResultTest {
+    companion object {
+        val collectionIndex = 1
+        val startStateBytes = ByteArray(32) { 0x01 }
+        val eventCollectionBytes = ByteArray(32) { 0x02 }
+        val totalComputationUsed = 1000L
+        val numberOfTransactions = 10
+        val index = 5L
+        val endStateBytes = ByteArray(32) { 0x04 }
+        val executionDataIdBytes = ByteArray(32) { 0x05 }
+        val stateDeltaCommitmentBytes = ByteArray(32) { 0x06 }
+        val payloadBytes = ByteArray(32) { 0x07 }
+
+        val blockIdBytes = ByteArray(32) { 0x01 }
+        val previousResultIdBytes = ByteArray(32) { 0x02 }
+    }
+
+    @Test
+    fun `test of() method with ExecutionResultByIDResponse`() {
+        // Mock inner ExecutionResult
+        val grpcExecutionResultInner = mock(ExecutionResultOuterClass.ExecutionResult::class.java)
+        `when`(grpcExecutionResultInner.blockId).thenReturn(ByteString.copyFrom(blockIdBytes))
+        `when`(grpcExecutionResultInner.previousResultId).thenReturn(ByteString.copyFrom(previousResultIdBytes))
+
+        // Mock flow chunk
+        val grpcChunk = mock(ExecutionResultOuterClass.Chunk::class.java)
+        `when`(grpcChunk.collectionIndex).thenReturn(collectionIndex)
+        `when`(grpcChunk.startState).thenReturn(ByteString.copyFrom(startStateBytes))
+        `when`(grpcChunk.eventCollection).thenReturn(ByteString.copyFrom(eventCollectionBytes))
+        `when`(grpcChunk.blockId).thenReturn(ByteString.copyFrom(blockIdBytes))
+        `when`(grpcChunk.totalComputationUsed).thenReturn(totalComputationUsed)
+        `when`(grpcChunk.numberOfTransactions).thenReturn(numberOfTransactions)
+        `when`(grpcChunk.index).thenReturn(index)
+        `when`(grpcChunk.endState).thenReturn(ByteString.copyFrom(endStateBytes))
+        `when`(grpcChunk.executionDataId).thenReturn(ByteString.copyFrom(executionDataIdBytes))
+        `when`(grpcChunk.stateDeltaCommitment).thenReturn(ByteString.copyFrom(stateDeltaCommitmentBytes))
+
+        `when`(grpcExecutionResultInner.chunksList).thenReturn(listOf(grpcChunk))
+
+        // Mock service event
+        val serviceEvent = mock(ExecutionResultOuterClass.ServiceEvent::class.java)
+        `when`(serviceEvent.type).thenReturn("EventType")  // Mock the getType() method
+        `when`(serviceEvent.payload).thenReturn(ByteString.copyFrom(payloadBytes))
+        `when`(grpcExecutionResultInner.serviceEventsList).thenReturn(listOf(serviceEvent))
+
+        // Mock outer Access.ExecutionResultByIDResponse
+        val grpcExecutionResult = mock(Access.ExecutionResultByIDResponse::class.java)
+        `when`(grpcExecutionResult.executionResult).thenReturn(grpcExecutionResultInner)
+
+        val flowExecutionResult = FlowExecutionResult.of(grpcExecutionResult)
+
+        assertEquals(FlowId.of(blockIdBytes), flowExecutionResult.blockId)
+        assertEquals(FlowId.of(previousResultIdBytes), flowExecutionResult.previousResultId)
+        assertEquals(1, flowExecutionResult.chunks.size)
+        assertEquals(1, flowExecutionResult.serviceEvents.size)
+        assertEquals("EventType", flowExecutionResult.serviceEvents[0].type)
+        assertArrayEquals(payloadBytes, flowExecutionResult.serviceEvents[0].payload)
+    }
+
+    @Test
+    fun `test of() method with ExecutionResult`() {
+        // Mock flow chunk
+        val grpcChunk = mock(ExecutionResultOuterClass.Chunk::class.java)
+        `when`(grpcChunk.collectionIndex).thenReturn(collectionIndex)
+        `when`(grpcChunk.startState).thenReturn(ByteString.copyFrom(startStateBytes))
+        `when`(grpcChunk.eventCollection).thenReturn(ByteString.copyFrom(eventCollectionBytes))
+        `when`(grpcChunk.blockId).thenReturn(ByteString.copyFrom(blockIdBytes))
+        `when`(grpcChunk.totalComputationUsed).thenReturn(totalComputationUsed)
+        `when`(grpcChunk.numberOfTransactions).thenReturn(numberOfTransactions)
+        `when`(grpcChunk.index).thenReturn(index)
+        `when`(grpcChunk.endState).thenReturn(ByteString.copyFrom(endStateBytes))
+        `when`(grpcChunk.executionDataId).thenReturn(ByteString.copyFrom(executionDataIdBytes))
+        `when`(grpcChunk.stateDeltaCommitment).thenReturn(ByteString.copyFrom(stateDeltaCommitmentBytes))
+
+        // Mock service event
+        val serviceEvent = mock(ExecutionResultOuterClass.ServiceEvent::class.java)
+        `when`(serviceEvent.type).thenReturn("EventType")  // Mock the getType() method
+        `when`(serviceEvent.payload).thenReturn(ByteString.copyFrom(payloadBytes))  // Mock the getPayload() method
+
+        // Mock ExecutionResult
+        val grpcExecutionResult = mock(ExecutionResultOuterClass.ExecutionResult::class.java)
+        `when`(grpcExecutionResult.blockId).thenReturn(ByteString.copyFrom(blockIdBytes))
+        `when`(grpcExecutionResult.previousResultId).thenReturn(ByteString.copyFrom(previousResultIdBytes))
+        `when`(grpcExecutionResult.chunksList).thenReturn(listOf(grpcChunk))
+        `when`(grpcExecutionResult.serviceEventsList).thenReturn(listOf(serviceEvent))
+
+        val flowExecutionResult = FlowExecutionResult.of(grpcExecutionResult)
+
+        assertEquals(FlowId.of(blockIdBytes), flowExecutionResult.blockId)
+        assertEquals(FlowId.of(previousResultIdBytes), flowExecutionResult.previousResultId)
+        assertEquals(1, flowExecutionResult.chunks.size)
+        assertEquals(1, flowExecutionResult.serviceEvents.size)
+        assertEquals("EventType", flowExecutionResult.serviceEvents[0].type)  // Validate the service event type
+        assertArrayEquals(payloadBytes, flowExecutionResult.serviceEvents[0].payload)  // Validate the service event payload
+    }
+
+    @Test
+    fun `test builder() method`() {
+        val blockIdBytes = ByteArray(32) { 0x01 }
+        val previousResultIdBytes = ByteArray(32) { 0x02 }
+        val blockId = FlowId.of(blockIdBytes)
+        val previousResultId = FlowId.of(previousResultIdBytes)
+
+        // Mock FlowChunk and its builder
+        val chunk = mock(FlowChunk::class.java)
+        val chunkBuilder = mock(ExecutionResultOuterClass.Chunk.Builder::class.java)
+
+        // Set up the behavior for the builder methods
+        `when`(chunk.builder()).thenReturn(chunkBuilder)
+        `when`(chunkBuilder.build()).thenReturn(ExecutionResultOuterClass.Chunk.newBuilder()
+            .setCollectionIndex(1)
+            .setBlockId(ByteString.copyFrom(blockIdBytes))
+            .build())  // Return a valid Chunk object with required fields
+
+        // Mock FlowServiceEvent and its builder
+        val serviceEvent = mock(FlowServiceEvent::class.java)
+        val serviceEventBuilder = mock(ExecutionResultOuterClass.ServiceEvent.Builder::class.java)
+
+        // Set up the behavior for the service event builder
+        `when`(serviceEvent.builder()).thenReturn(serviceEventBuilder)
+        `when`(serviceEventBuilder.build()).thenReturn(ExecutionResultOuterClass.ServiceEvent.newBuilder()
+            .setType("EventType")
+            .setPayload(ByteString.copyFrom(ByteArray(32) { 0x07 }))  // Use any valid ByteString payload
+            .build())  // Ensure this returns a valid built object
+
+        // Create FlowExecutionResult instance with mocks
+        val flowExecutionResult = FlowExecutionResult(
+            blockId = blockId,
+            previousResultId = previousResultId,
+            chunks = listOf(chunk),
+            serviceEvents = listOf(serviceEvent)
+        )
+
+        // Call the builder() method and build the result
+        val result = flowExecutionResult.builder().build()
+
+        // Assertions to verify the builder results
+        assertEquals(blockId.byteStringValue, result.blockId)
+        assertEquals(previousResultId.byteStringValue, result.previousResultId)
+        assertEquals(1, result.chunksCount)
+        assertEquals(1, result.serviceEventsCount)
+
+        // Verify that the builders for the chunks and service events were invoked
+        verify(chunk).builder()
+        verify(serviceEvent).builder()
+    }
+
+    @Test
+    fun `test equals() method`() {
+        val blockId1 = FlowId.of(ByteArray(32) { 0x01 })
+        val previousResultId1 = FlowId.of(ByteArray(32) { 0x02 })
+        val chunk1 = mock(FlowChunk::class.java)
+        val serviceEvent1 = mock(FlowServiceEvent::class.java)
+
+        val blockId2 = FlowId.of(ByteArray(32) { 0x03 })
+        val previousResultId2 = FlowId.of(ByteArray(32) { 0x04 })
+        val chunk2 = mock(FlowChunk::class.java)
+        val serviceEvent2 = mock(FlowServiceEvent::class.java)
+
+        val flowExecutionResult1 = FlowExecutionResult(
+            blockId = blockId1,
+            previousResultId = previousResultId1,
+            chunks = listOf(chunk1),
+            serviceEvents = listOf(serviceEvent1)
+        )
+
+        val flowExecutionResult2 = FlowExecutionResult(
+            blockId = blockId1,
+            previousResultId = previousResultId1,
+            chunks = listOf(chunk1),
+            serviceEvents = listOf(serviceEvent1)
+        )
+
+        val flowExecutionResult3 = FlowExecutionResult(
+            blockId = blockId2,
+            previousResultId = previousResultId2,
+            chunks = listOf(chunk2),
+            serviceEvents = listOf(serviceEvent2)
+        )
+
+        assertEquals(flowExecutionResult1, flowExecutionResult2)
+        assertNotEquals(flowExecutionResult1, flowExecutionResult3)
+    }
+
+    @Test
+    fun `test hashCode() method`() {
+        val blockId1 = FlowId.of(ByteArray(32) { 0x01 })
+        val previousResultId1 = FlowId.of(ByteArray(32) { 0x02 })
+        val chunk1 = mock(FlowChunk::class.java)
+        val serviceEvent1 = mock(FlowServiceEvent::class.java)
+
+        val blockId2 = FlowId.of(ByteArray(32) { 0x03 })
+        val previousResultId2 = FlowId.of(ByteArray(32) { 0x04 })
+        val chunk2 = mock(FlowChunk::class.java)
+        val serviceEvent2 = mock(FlowServiceEvent::class.java)
+
+        val flowExecutionResult1 = FlowExecutionResult(
+            blockId = blockId1,
+            previousResultId = previousResultId1,
+            chunks = listOf(chunk1),
+            serviceEvents = listOf(serviceEvent1)
+        )
+
+        val flowExecutionResult2 = FlowExecutionResult(
+            blockId = blockId1,
+            previousResultId = previousResultId1,
+            chunks = listOf(chunk1),
+            serviceEvents = listOf(serviceEvent1)
+        )
+
+        val flowExecutionResult3 = FlowExecutionResult(
+            blockId = blockId2,
+            previousResultId = previousResultId2,
+            chunks = listOf(chunk2),
+            serviceEvents = listOf(serviceEvent2)
+        )
+
+        assertEquals(flowExecutionResult1.hashCode(), flowExecutionResult2.hashCode())
+        assertNotEquals(flowExecutionResult1.hashCode(), flowExecutionResult3.hashCode())
+    }
 }

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionResultTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowExecutionResultTest.kt
@@ -106,10 +106,8 @@ class FlowExecutionResultTest {
 
     @Test
     fun `test builder() method`() {
-        // Setup mock FlowServiceEvent
         val serviceEvent = FlowServiceEvent("EventType", blockIdBytes)
 
-        // Setup mock FlowChunk
         val flowChunk = FlowChunk(
             collectionIndex = collectionIndex,
             startState = startStateBytes,

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowQuorumCertificateTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowQuorumCertificateTest.kt
@@ -1,0 +1,4 @@
+package org.onflow.flow.sdk.models
+
+class FlowQuorumCertificateTest {
+}

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowQuorumCertificateTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowQuorumCertificateTest.kt
@@ -9,7 +9,6 @@ import org.onflow.flow.sdk.FlowQuorumCertificate
 import org.onflow.protobuf.entities.BlockHeaderOuterClass
 
 class FlowQuorumCertificateTest {
-
     @Test
     fun `test of() method`() {
         val view = 123L
@@ -88,4 +87,3 @@ class FlowQuorumCertificateTest {
         assertNotEquals(flowQuorumCertificate1.hashCode(), flowQuorumCertificate3.hashCode())
     }
 }
-

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowQuorumCertificateTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowQuorumCertificateTest.kt
@@ -1,4 +1,91 @@
 package org.onflow.flow.sdk.models
 
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import com.google.protobuf.ByteString
+import org.onflow.flow.sdk.FlowId
+import org.onflow.flow.sdk.FlowQuorumCertificate
+import org.onflow.protobuf.entities.BlockHeaderOuterClass
+
 class FlowQuorumCertificateTest {
+
+    @Test
+    fun `test of() method`() {
+        val view = 123L
+        val blockIdBytes = ByteArray(32) { 0x01 }
+        val signerIndicesBytes = ByteArray(32) { 0x02 }
+        val sigDataBytes = ByteArray(32) { 0x03 }
+
+        val grpcQuorumCertificate = mock(BlockHeaderOuterClass.QuorumCertificate::class.java)
+        `when`(grpcQuorumCertificate.view).thenReturn(view)
+        `when`(grpcQuorumCertificate.blockId).thenReturn(ByteString.copyFrom(blockIdBytes))
+        `when`(grpcQuorumCertificate.signerIndices).thenReturn(ByteString.copyFrom(signerIndicesBytes))
+        `when`(grpcQuorumCertificate.sigData).thenReturn(ByteString.copyFrom(sigDataBytes))
+
+        val flowQuorumCertificate = FlowQuorumCertificate.of(grpcQuorumCertificate)
+
+        assertEquals(view, flowQuorumCertificate.view)
+        assertArrayEquals(blockIdBytes, flowQuorumCertificate.blockId.bytes)
+        assertArrayEquals(signerIndicesBytes, flowQuorumCertificate.signerIndices)
+        assertArrayEquals(sigDataBytes, flowQuorumCertificate.sigData)
+    }
+
+    @Test
+    fun `test builder() method`() {
+        val view = 123L
+        val blockId = FlowId.of(ByteArray(32) { 0x01 })
+        val signerIndices = ByteArray(32) { 0x02 }
+        val sigData = ByteArray(32) { 0x03 }
+
+        val flowQuorumCertificate = FlowQuorumCertificate(view, blockId, signerIndices, sigData)
+
+        val builder = flowQuorumCertificate.builder().build()
+
+        assertEquals(view, builder.view)
+        assertArrayEquals(blockId.bytes, builder.blockId.toByteArray())
+        assertArrayEquals(signerIndices, builder.signerIndices.toByteArray())
+        assertArrayEquals(sigData, builder.sigData.toByteArray())
+    }
+
+    @Test
+    fun `test equals() method`() {
+        val view1 = 123L
+        val blockId1 = FlowId.of(ByteArray(32) { 0x01 })
+        val signerIndices1 = ByteArray(32) { 0x02 }
+        val sigData1 = ByteArray(32) { 0x03 }
+
+        val view2 = 124L
+        val blockId2 = FlowId.of(ByteArray(32) { 0x04 })
+        val signerIndices2 = ByteArray(32) { 0x05 }
+        val sigData2 = ByteArray(32) { 0x06 }
+
+        val flowQuorumCertificate1 = FlowQuorumCertificate(view1, blockId1, signerIndices1, sigData1)
+        val flowQuorumCertificate2 = FlowQuorumCertificate(view1, blockId1, signerIndices1, sigData1)
+        val flowQuorumCertificate3 = FlowQuorumCertificate(view2, blockId2, signerIndices2, sigData2)
+
+        assertEquals(flowQuorumCertificate1, flowQuorumCertificate2)
+        assertNotEquals(flowQuorumCertificate1, flowQuorumCertificate3)
+    }
+
+    @Test
+    fun `test hashCode() method`() {
+        val view1 = 123L
+        val blockId1 = FlowId.of(ByteArray(32) { 0x01 })
+        val signerIndices1 = ByteArray(32) { 0x02 }
+        val sigData1 = ByteArray(32) { 0x03 }
+
+        val view2 = 124L
+        val blockId2 = FlowId.of(ByteArray(32) { 0x04 })
+        val signerIndices2 = ByteArray(32) { 0x05 }
+        val sigData2 = ByteArray(32) { 0x06 }
+
+        val flowQuorumCertificate1 = FlowQuorumCertificate(view1, blockId1, signerIndices1, sigData1)
+        val flowQuorumCertificate2 = FlowQuorumCertificate(view1, blockId1, signerIndices1, sigData1)
+        val flowQuorumCertificate3 = FlowQuorumCertificate(view2, blockId2, signerIndices2, sigData2)
+
+        assertEquals(flowQuorumCertificate1.hashCode(), flowQuorumCertificate2.hashCode())
+        assertNotEquals(flowQuorumCertificate1.hashCode(), flowQuorumCertificate3.hashCode())
+    }
 }
+

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTimeoutCertificateTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTimeoutCertificateTest.kt
@@ -44,7 +44,7 @@ class FlowTimeoutCertificateTest {
 
     @Test
     fun `test builder() method`() {
-        // mock FlowQuorumCertificate
+        // Mock FlowQuorumCertificate
         val view = 123L
         val blockIdBytes = ByteArray(32) { 0x01 }
         val signerIndicesBytes = ByteArray(32) { 0x02 }
@@ -58,7 +58,7 @@ class FlowTimeoutCertificateTest {
 
         val flowQuorumCertificate = FlowQuorumCertificate.of(grpcQuorumCertificate)
 
-        // mock FlowTimeoutCertificate
+        // Mock FlowTimeoutCertificate
         val highQcViews = listOf(1L, 2L)
         val signerIndices = byteArrayOf(1, 2)
         val sigData = byteArrayOf(3, 4)

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTimeoutCertificateTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTimeoutCertificateTest.kt
@@ -1,4 +1,130 @@
 package org.onflow.flow.sdk.models
 
+import com.google.protobuf.ByteString
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.onflow.flow.sdk.FlowQuorumCertificate
+import org.onflow.flow.sdk.FlowTimeoutCertificate
+import org.onflow.protobuf.entities.BlockHeaderOuterClass
+
 class FlowTimeoutCertificateTest {
+    @Test
+    fun `test of() method`() {
+        val view = 123L
+        val highQcViews = listOf(456L, 789L)
+        val signerIndicesBytes = ByteArray(32) { 0x01 }
+        val sigDataBytes = ByteArray(32) { 0x02 }
+
+        // mock QuorumCertificate
+        val grpcHighestQc = mock(BlockHeaderOuterClass.QuorumCertificate::class.java)
+        `when`(grpcHighestQc.view).thenReturn(view)
+        `when`(grpcHighestQc.blockId).thenReturn(ByteString.copyFrom(ByteArray(32) { 0x01 }))
+        `when`(grpcHighestQc.signerIndices).thenReturn(ByteString.copyFrom(ByteArray(32) { 0x02 }))
+        `when`(grpcHighestQc.sigData).thenReturn(ByteString.copyFrom(ByteArray(32) { 0x03 }))
+
+        val highestQc = FlowQuorumCertificate.of(grpcHighestQc)
+
+        // mock TimeoutCertificate
+        val grpcTimeoutCertificate = mock(BlockHeaderOuterClass.TimeoutCertificate::class.java)
+        `when`(grpcTimeoutCertificate.view).thenReturn(view)
+        `when`(grpcTimeoutCertificate.highQcViewsList).thenReturn(highQcViews)
+        `when`(grpcTimeoutCertificate.highestQc).thenReturn(grpcHighestQc) // Return the mocked QuorumCertificate
+        `when`(grpcTimeoutCertificate.signerIndices).thenReturn(ByteString.copyFrom(signerIndicesBytes))
+        `when`(grpcTimeoutCertificate.sigData).thenReturn(ByteString.copyFrom(sigDataBytes))
+
+        val flowTimeoutCertificate = FlowTimeoutCertificate.of(grpcTimeoutCertificate)
+
+        assertEquals(view, flowTimeoutCertificate.view)
+        assertEquals(highQcViews, flowTimeoutCertificate.highQcViews)
+        assertEquals(highestQc, flowTimeoutCertificate.highestQc)
+        assertArrayEquals(signerIndicesBytes, flowTimeoutCertificate.signerIndices)
+        assertArrayEquals(sigDataBytes, flowTimeoutCertificate.sigData)
+    }
+
+    @Test
+    fun `test builder() method`() {
+
+        // mock FlowQuorumCertificate
+        val view = 123L
+        val blockIdBytes = ByteArray(32) { 0x01 }
+        val signerIndicesBytes = ByteArray(32) { 0x02 }
+        val sigDataBytes = ByteArray(32) { 0x03 }
+
+        val grpcQuorumCertificate = mock(BlockHeaderOuterClass.QuorumCertificate::class.java)
+        `when`(grpcQuorumCertificate.view).thenReturn(view)
+        `when`(grpcQuorumCertificate.blockId).thenReturn(ByteString.copyFrom(blockIdBytes))
+        `when`(grpcQuorumCertificate.signerIndices).thenReturn(ByteString.copyFrom(signerIndicesBytes))
+        `when`(grpcQuorumCertificate.sigData).thenReturn(ByteString.copyFrom(sigDataBytes))
+
+        val flowQuorumCertificate = FlowQuorumCertificate.of(grpcQuorumCertificate)
+
+        // mock FlowTimeoutCertificate
+        val highQcViews = listOf(1L, 2L)
+        val signerIndices = byteArrayOf(1, 2)
+        val sigData = byteArrayOf(3, 4)
+
+        val timeoutCertificate = FlowTimeoutCertificate(
+            view = view,
+            highQcViews = highQcViews,
+            highestQc = flowQuorumCertificate,
+            signerIndices = signerIndices,
+            sigData = sigData
+        )
+
+        val result = timeoutCertificate.builder().build()
+
+        assertEquals(view, result.view)
+        assertEquals(highQcViews, result.highQcViewsList)
+        assertEquals(ByteString.copyFrom(signerIndices), result.signerIndices)
+        assertEquals(ByteString.copyFrom(sigData), result.sigData)
+        assertEquals(flowQuorumCertificate.builder().build(), result.highestQc)
+    }
+
+    @Test
+    fun `test equals() method`() {
+        val view1 = 123L
+        val highQcViews1 = listOf(456L, 789L)
+        val signerIndices1 = ByteArray(32) { 0x01 }
+        val sigData1 = ByteArray(32) { 0x02 }
+
+        val view2 = 124L
+        val highQcViews2 = listOf(111L, 222L)
+        val signerIndices2 = ByteArray(32) { 0x03 }
+        val sigData2 = ByteArray(32) { 0x04 }
+
+        val highestQc1 = mock(FlowQuorumCertificate::class.java)
+        val highestQc2 = mock(FlowQuorumCertificate::class.java)
+
+        val flowTimeoutCertificate1 = FlowTimeoutCertificate(view1, highQcViews1, highestQc1, signerIndices1, sigData1)
+        val flowTimeoutCertificate2 = FlowTimeoutCertificate(view1, highQcViews1, highestQc1, signerIndices1, sigData1)
+        val flowTimeoutCertificate3 = FlowTimeoutCertificate(view2, highQcViews2, highestQc2, signerIndices2, sigData2)
+
+        assertEquals(flowTimeoutCertificate1, flowTimeoutCertificate2)
+        assertNotEquals(flowTimeoutCertificate1, flowTimeoutCertificate3)
+    }
+
+    @Test
+    fun `test hashCode() method`() {
+        val view1 = 123L
+        val highQcViews1 = listOf(456L, 789L)
+        val signerIndices1 = ByteArray(32) { 0x01 }
+        val sigData1 = ByteArray(32) { 0x02 }
+
+        val view2 = 124L
+        val highQcViews2 = listOf(111L, 222L)
+        val signerIndices2 = ByteArray(32) { 0x03 }
+        val sigData2 = ByteArray(32) { 0x04 }
+
+        val highestQc1 = mock(FlowQuorumCertificate::class.java)
+        val highestQc2 = mock(FlowQuorumCertificate::class.java)
+
+        val flowTimeoutCertificate1 = FlowTimeoutCertificate(view1, highQcViews1, highestQc1, signerIndices1, sigData1)
+        val flowTimeoutCertificate2 = FlowTimeoutCertificate(view1, highQcViews1, highestQc1, signerIndices1, sigData1)
+        val flowTimeoutCertificate3 = FlowTimeoutCertificate(view2, highQcViews2, highestQc2, signerIndices2, sigData2)
+
+        assertEquals(flowTimeoutCertificate1.hashCode(), flowTimeoutCertificate2.hashCode())
+        assertNotEquals(flowTimeoutCertificate1.hashCode(), flowTimeoutCertificate3.hashCode())
+    }
 }
+

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTimeoutCertificateTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTimeoutCertificateTest.kt
@@ -44,7 +44,6 @@ class FlowTimeoutCertificateTest {
 
     @Test
     fun `test builder() method`() {
-
         // mock FlowQuorumCertificate
         val view = 123L
         val blockIdBytes = ByteArray(32) { 0x01 }
@@ -127,4 +126,3 @@ class FlowTimeoutCertificateTest {
         assertNotEquals(flowTimeoutCertificate1.hashCode(), flowTimeoutCertificate3.hashCode())
     }
 }
-

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTimeoutCertificateTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/models/FlowTimeoutCertificateTest.kt
@@ -1,0 +1,4 @@
+package org.onflow.flow.sdk.models
+
+class FlowTimeoutCertificateTest {
+}


### PR DESCRIPTION
Closes: #110

## Description

- Update fields for `FlowCollectionGuarantee` model: https://github.com/onflow/flow/blob/master/protobuf/flow/entities/collection.proto#L13
- Did not add `signer_ids` as it has been deprecated
- Update related tests with new fields

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
