### PR TITLE
Add `fullBlockResponse` param to Access API block requests

### DIFF
--- a/java-example/src/main/java/org/onflow/examples/java/getBlock/GetBlockAccessAPIConnector.java
+++ b/java-example/src/main/java/org/onflow/examples/java/getBlock/GetBlockAccessAPIConnector.java
@@ -11,7 +11,8 @@ public class GetBlockAccessAPIConnector {
 
     public FlowBlock getLatestSealedBlock() {
         boolean isSealed = true;
-        FlowAccessApi.AccessApiCallResponse<FlowBlock> response = accessAPI.getLatestBlock(isSealed);
+        boolean fullBlockResponse = false;
+        FlowAccessApi.AccessApiCallResponse<FlowBlock> response = accessAPI.getLatestBlock(isSealed, fullBlockResponse);
 
         if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
             return ((FlowAccessApi.AccessApiCallResponse.Success<FlowBlock>) response).getData();
@@ -22,7 +23,8 @@ public class GetBlockAccessAPIConnector {
     }
 
     public FlowBlock getBlockByID(FlowId blockID) {
-        FlowAccessApi.AccessApiCallResponse<FlowBlock> response = accessAPI.getBlockById(blockID);
+        boolean fullBlockResponse = false;
+        FlowAccessApi.AccessApiCallResponse<FlowBlock> response = accessAPI.getBlockById(blockID, fullBlockResponse);
 
         if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
             return ((FlowAccessApi.AccessApiCallResponse.Success<FlowBlock>) response).getData();
@@ -33,7 +35,8 @@ public class GetBlockAccessAPIConnector {
     }
 
     public FlowBlock getBlockByHeight(long height) {
-        FlowAccessApi.AccessApiCallResponse<FlowBlock> response = accessAPI.getBlockByHeight(height);
+        boolean fullBlockResponse = false;
+        FlowAccessApi.AccessApiCallResponse<FlowBlock> response = accessAPI.getBlockByHeight(height, fullBlockResponse);
 
         if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
             return ((FlowAccessApi.AccessApiCallResponse.Success<FlowBlock>) response).getData();

--- a/java-example/src/test/java/org/onflow/examples/java/getAccountBalance/GetAccountBalanceAccessAPIConnectorTest.java
+++ b/java-example/src/test/java/org/onflow/examples/java/getAccountBalance/GetAccountBalanceAccessAPIConnectorTest.java
@@ -39,7 +39,7 @@ public class GetAccountBalanceAccessAPIConnectorTest {
     public void testCanFetchBalanceAtSpecificBlockHeight() {
         FlowAddress address = serviceAccount.getFlowAddress();
 
-        FlowAccessApi.AccessApiCallResponse<FlowBlock> latestBlockResponse = accessAPI.getLatestBlock(true);
+        FlowAccessApi.AccessApiCallResponse<FlowBlock> latestBlockResponse = accessAPI.getLatestBlock(true, false);
 
         if (latestBlockResponse instanceof FlowAccessApi.AccessApiCallResponse.Success) {
             FlowBlock latestBlock = ((FlowAccessApi.AccessApiCallResponse.Success<FlowBlock>) latestBlockResponse).getData();
@@ -58,7 +58,7 @@ public class GetAccountBalanceAccessAPIConnectorTest {
         FlowAddress address = serviceAccount.getFlowAddress();
 
         long balanceAtLatest = balanceAPIConnector.getBalanceAtLatestBlock(address);
-        FlowAccessApi.AccessApiCallResponse<FlowBlock> latestBlockResponse = accessAPI.getLatestBlock(true);
+        FlowAccessApi.AccessApiCallResponse<FlowBlock> latestBlockResponse = accessAPI.getLatestBlock(true, false);
 
         if (latestBlockResponse instanceof FlowAccessApi.AccessApiCallResponse.Success) {
             FlowBlock latestBlock = ((FlowAccessApi.AccessApiCallResponse.Success<FlowBlock>) latestBlockResponse).getData();

--- a/java-example/src/test/java/org/onflow/examples/java/getCollection/GetCollectionAccessAPIConnectorTest.java
+++ b/java-example/src/test/java/org/onflow/examples/java/getCollection/GetCollectionAccessAPIConnectorTest.java
@@ -34,7 +34,7 @@ public class GetCollectionAccessAPIConnectorTest {
             publicKey
         );
 
-        FlowAccessApi.AccessApiCallResponse<FlowBlock> response = accessAPI.getLatestBlock(true);
+        FlowAccessApi.AccessApiCallResponse<FlowBlock> response = accessAPI.getLatestBlock(true, false);
         if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
             FlowBlock block = ((FlowAccessApi.AccessApiCallResponse.Success<FlowBlock>) response).getData();
             collectionId = block.getCollectionGuarantees().get(0).getId();

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
@@ -12,15 +12,15 @@ interface AsyncFlowAccessApi {
 
     fun getBlockHeaderByHeight(height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlockHeader?>>
 
-    fun getLatestBlock(sealed: Boolean = true): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock>>
+    fun getLatestBlock(sealed: Boolean = true, fullBlockResponse: Boolean = false): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock>>
 
     fun getAccountBalanceAtLatestBlock(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<Long>>
 
     fun getAccountBalanceAtBlockHeight(address: FlowAddress, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<Long>>
 
-    fun getBlockById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>>
+    fun getBlockById(id: FlowId, fullBlockResponse: Boolean = false): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>>
 
-    fun getBlockByHeight(height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>>
+    fun getBlockByHeight(height: Long, fullBlockResponse: Boolean = false): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>>
 
     fun getCollectionById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowCollection?>>
 

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
@@ -24,15 +24,14 @@ interface FlowAccessApi {
 
     fun getBlockHeaderByHeight(height: Long): AccessApiCallResponse<FlowBlockHeader>
 
-    fun getLatestBlock(sealed: Boolean = true): AccessApiCallResponse<FlowBlock>
+    fun getLatestBlock(sealed: Boolean = true, fullBlockResponse: Boolean = false): AccessApiCallResponse<FlowBlock>
 
+    fun getBlockById(id: FlowId, fullBlockResponse: Boolean = false): AccessApiCallResponse<FlowBlock>
     fun getAccountBalanceAtLatestBlock(address: FlowAddress): AccessApiCallResponse<Long>
 
     fun getAccountBalanceAtBlockHeight(address: FlowAddress, height: Long): AccessApiCallResponse<Long>
 
-    fun getBlockById(id: FlowId): AccessApiCallResponse<FlowBlock>
-
-    fun getBlockByHeight(height: Long): AccessApiCallResponse<FlowBlock>
+    fun getBlockByHeight(height: Long, fullBlockResponse: Boolean = false): AccessApiCallResponse<FlowBlock>
 
     fun getCollectionById(id: FlowId): AccessApiCallResponse<FlowCollection>
 

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -127,7 +127,7 @@ class AsyncFlowAccessApiImpl(
         }
     }
 
-    override fun getLatestBlock(sealed: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock>> {
+    override fun getLatestBlock(sealed: Boolean, fullBlockResponse: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock>> {
         return try {
             completableFuture(
                 try {
@@ -135,6 +135,7 @@ class AsyncFlowAccessApiImpl(
                         Access.GetLatestBlockRequest
                             .newBuilder()
                             .setIsSealed(sealed)
+                            .setFullBlockResponse(fullBlockResponse)
                             .build()
                     )
                 } catch (e: Exception) {
@@ -203,7 +204,7 @@ class AsyncFlowAccessApiImpl(
         }
     }
 
-    override fun getBlockById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>> {
+    override fun getBlockById(id: FlowId, fullBlockResponse: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>> {
         return try {
             completableFuture(
                 try {
@@ -211,6 +212,7 @@ class AsyncFlowAccessApiImpl(
                         Access.GetBlockByIDRequest
                             .newBuilder()
                             .setId(id.byteStringValue)
+                            .setFullBlockResponse(fullBlockResponse)
                             .build()
                     )
                 } catch (e: Exception) {
@@ -232,7 +234,7 @@ class AsyncFlowAccessApiImpl(
         }
     }
 
-    override fun getBlockByHeight(height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>> {
+    override fun getBlockByHeight(height: Long, fullBlockResponse: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>> {
         return try {
             completableFuture(
                 try {
@@ -240,6 +242,7 @@ class AsyncFlowAccessApiImpl(
                         Access.GetBlockByHeightRequest
                             .newBuilder()
                             .setHeight(height)
+                            .setFullBlockResponse(fullBlockResponse)
                             .build()
                     )
                 } catch (e: Exception) {

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
@@ -83,12 +83,13 @@ class FlowAccessApiImpl(
             FlowAccessApi.AccessApiCallResponse.Error("Failed to get block header by height", e)
         }
 
-    override fun getLatestBlock(sealed: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlock> =
+    override fun getLatestBlock(sealed: Boolean, fullBlockResponse: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlock> =
         try {
             val ret = api.getLatestBlock(
                 Access.GetLatestBlockRequest
                     .newBuilder()
                     .setIsSealed(sealed)
+                    .setFullBlockResponse(fullBlockResponse)
                     .build()
             )
             FlowAccessApi.AccessApiCallResponse.Success(FlowBlock.of(ret.block))
@@ -123,12 +124,13 @@ class FlowAccessApiImpl(
             FlowAccessApi.AccessApiCallResponse.Error("Failed to get account balance at block height", e)
         }
 
-    override fun getBlockById(id: FlowId): FlowAccessApi.AccessApiCallResponse<FlowBlock> =
+    override fun getBlockById(id: FlowId, fullBlockResponse: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlock> =
         try {
             val ret = api.getBlockByID(
                 Access.GetBlockByIDRequest
                     .newBuilder()
                     .setId(id.byteStringValue)
+                    .setFullBlockResponse(fullBlockResponse)
                     .build()
             )
             if (ret.hasBlock()) {
@@ -140,12 +142,13 @@ class FlowAccessApiImpl(
             FlowAccessApi.AccessApiCallResponse.Error("Failed to get block by ID", e)
         }
 
-    override fun getBlockByHeight(height: Long): FlowAccessApi.AccessApiCallResponse<FlowBlock> =
+    override fun getBlockByHeight(height: Long, fullBlockResponse: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlock> =
         try {
             val ret = api.getBlockByHeight(
                 Access.GetBlockByHeightRequest
                     .newBuilder()
                     .setHeight(height)
+                    .setFullBlockResponse(fullBlockResponse)
                     .build()
             )
             if (ret.hasBlock()) {


### PR DESCRIPTION
Closes: #109

## Description

- Add `fullBlockResponse` boolean field to get block Access API methods
- Defaults to false when a value is not passed

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced block retrieval methods with an optional parameter for full block responses, improving flexibility in API calls.

- **Deprecations**
	- The `getAccountByAddress` method is now deprecated; users are encouraged to use `getAccountAtLatestBlock` instead for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->