### PR TITLE
Get account key endpoints

### DIFF
--- a/java-example/README.md
+++ b/java-example/README.md
@@ -53,6 +53,10 @@ Below is a list of all Java code examples currently supported in this repo:
 - Get account balance
 - Get account from the latest block
 - Get account from block by height
+- Get account key at latest block
+- Get account keys at latest block
+- Get account key at block height
+- Get account keys at block height
 
 #### Get Events
 

--- a/java-example/README.md
+++ b/java-example/README.md
@@ -80,6 +80,7 @@ Below is a list of all Java code examples currently supported in this repo:
 
 - Get transaction
 - Get transaction result
+- Get transaction result by index
 
 #### Sending Transactions
 

--- a/java-example/src/main/java/org/onflow/examples/java/getAccountKeys/GetAccountKeysAccessAPIConnector.java
+++ b/java-example/src/main/java/org/onflow/examples/java/getAccountKeys/GetAccountKeysAccessAPIConnector.java
@@ -1,0 +1,59 @@
+package org.onflow.examples.java.getAccountKeys;
+
+import org.onflow.flow.sdk.FlowAccessApi;
+import org.onflow.flow.sdk.FlowAccountKey;
+import org.onflow.flow.sdk.FlowAddress;
+
+import java.util.List;
+
+public class GetAccountKeysAccessAPIConnector {
+    private final FlowAccessApi accessAPI;
+
+    public GetAccountKeysAccessAPIConnector(FlowAccessApi accessAPI) {
+        this.accessAPI = accessAPI;
+    }
+
+    public FlowAccountKey getAccountKeyAtLatestBlock(FlowAddress address, int keyIndex) {
+        FlowAccessApi.AccessApiCallResponse<FlowAccountKey> response = accessAPI.getAccountKeyAtLatestBlock(address, keyIndex);
+
+        if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            return ((FlowAccessApi.AccessApiCallResponse.Success<FlowAccountKey>) response).getData();
+        } else {
+            FlowAccessApi.AccessApiCallResponse.Error errorResponse = (FlowAccessApi.AccessApiCallResponse.Error) response;
+            throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
+        }
+    }
+
+    public FlowAccountKey getAccountKeyAtBlockHeight(FlowAddress address, int keyIndex, long height) {
+        FlowAccessApi.AccessApiCallResponse<FlowAccountKey> response = accessAPI.getAccountKeyAtBlockHeight(address, keyIndex, height);
+
+        if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            return ((FlowAccessApi.AccessApiCallResponse.Success<FlowAccountKey>) response).getData();
+        } else {
+            FlowAccessApi.AccessApiCallResponse.Error errorResponse = (FlowAccessApi.AccessApiCallResponse.Error) response;
+            throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
+        }
+    }
+
+    public List<FlowAccountKey> getAccountKeysAtLatestBlock(FlowAddress address) {
+        FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>> response = accessAPI.getAccountKeysAtLatestBlock(address);
+
+        if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            return ((FlowAccessApi.AccessApiCallResponse.Success<List<FlowAccountKey>>) response).getData();
+        } else {
+            FlowAccessApi.AccessApiCallResponse.Error errorResponse = (FlowAccessApi.AccessApiCallResponse.Error) response;
+            throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
+        }
+    }
+
+    public List<FlowAccountKey> getAccountKeysAtBlockHeight(FlowAddress address, long height) {
+        FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>> response = accessAPI.getAccountKeysAtBlockHeight(address, height);
+
+        if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            return ((FlowAccessApi.AccessApiCallResponse.Success<List<FlowAccountKey>>) response).getData();
+        } else {
+            FlowAccessApi.AccessApiCallResponse.Error errorResponse = (FlowAccessApi.AccessApiCallResponse.Error) response;
+            throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
+        }
+    }
+}

--- a/java-example/src/main/java/org/onflow/examples/java/getTransaction/GetTransactionAccessAPIConnector.java
+++ b/java-example/src/main/java/org/onflow/examples/java/getTransaction/GetTransactionAccessAPIConnector.java
@@ -31,4 +31,14 @@ public class GetTransactionAccessAPIConnector {
             throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
         }
     }
+
+    public FlowTransactionResult getTransactionResultByIndex(FlowId blockId, Integer index) {
+        FlowAccessApi.AccessApiCallResponse<FlowTransactionResult> response = accessAPI.getTransactionResultByIndex(blockId, index);
+        if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            return ((FlowAccessApi.AccessApiCallResponse.Success<FlowTransactionResult>) response).getData();
+        } else {
+            FlowAccessApi.AccessApiCallResponse.Error errorResponse = (FlowAccessApi.AccessApiCallResponse.Error) response;
+            throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
+        }
+    }
 }

--- a/java-example/src/test/java/org/onflow/examples/java/getAccountKeys/GetAccountKeysAccessAPIConnectorTest.java
+++ b/java-example/src/test/java/org/onflow/examples/java/getAccountKeys/GetAccountKeysAccessAPIConnectorTest.java
@@ -1,0 +1,114 @@
+package org.onflow.examples.java.getAccountKeys;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.onflow.flow.common.test.FlowEmulatorProjectTest;
+import org.onflow.flow.common.test.FlowServiceAccountCredentials;
+import org.onflow.flow.common.test.FlowTestClient;
+import org.onflow.flow.sdk.FlowAccessApi;
+import org.onflow.flow.sdk.FlowAddress;
+import org.onflow.flow.sdk.FlowAccountKey;
+import org.onflow.flow.common.test.TestAccount;
+import org.onflow.flow.sdk.FlowBlock;
+
+import java.util.List;
+
+@FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
+public class GetAccountKeysAccessAPIConnectorTest {
+    @FlowTestClient
+    private FlowAccessApi accessAPI;
+
+    @FlowServiceAccountCredentials
+    private TestAccount serviceAccount;
+
+    private GetAccountKeysAccessAPIConnector keysAPIConnector;
+
+    @BeforeEach
+    public void setup() {
+        keysAPIConnector = new GetAccountKeysAccessAPIConnector(accessAPI);
+    }
+
+    @Test
+    public void testCanFetchAccountKeyAtLatestBlock() {
+        FlowAddress address = serviceAccount.getFlowAddress();
+        int keyIndex = 0;
+
+        FlowAccountKey accountKey = keysAPIConnector.getAccountKeyAtLatestBlock(address, keyIndex);
+
+        Assertions.assertNotNull(accountKey, "Account key should not be null");
+        Assertions.assertEquals(keyIndex, accountKey.getSequenceNumber(), "Account key index should match the requested index");
+        Assertions.assertTrue(accountKey.getWeight() > 0, "Account key weight should be positive");
+    }
+
+    @Test
+    public void testCanFetchAccountKeyAtSpecificBlockHeight() {
+        FlowAddress address = serviceAccount.getFlowAddress();
+        int keyIndex = 0;
+
+        FlowAccessApi.AccessApiCallResponse<FlowBlock> latestBlockResponse = accessAPI.getLatestBlock(true, false);
+
+        if (latestBlockResponse instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            FlowBlock latestBlock = ((FlowAccessApi.AccessApiCallResponse.Success<FlowBlock>) latestBlockResponse).getData();
+            FlowAccountKey accountKey = keysAPIConnector.getAccountKeyAtBlockHeight(address, keyIndex, latestBlock.getHeight());
+
+            Assertions.assertNotNull(accountKey, "Account key at specific block height should not be null");
+            Assertions.assertEquals(keyIndex, accountKey.getSequenceNumber(), "Account key index at specific block height should match requested index");
+            Assertions.assertTrue(accountKey.getWeight() > 0, "Account key weight should be positive");
+
+        } else if (latestBlockResponse instanceof FlowAccessApi.AccessApiCallResponse.Error error) {
+            throw new RuntimeException("Failed to retrieve the latest block: " + error.getMessage(), error.getThrowable());
+        }
+    }
+
+    @Test
+    public void testCanFetchAllAccountKeysAtLatestBlock() {
+        FlowAddress address = serviceAccount.getFlowAddress();
+
+        List<FlowAccountKey> accountKeys = keysAPIConnector.getAccountKeysAtLatestBlock(address);
+
+        Assertions.assertNotNull(accountKeys, "Account keys list should not be null");
+        Assertions.assertFalse(accountKeys.isEmpty(), "Account keys list should not be empty");
+        accountKeys.forEach(key -> Assertions.assertTrue(key.getWeight() > 0, "Each account key weight should be positive"));
+    }
+
+    @Test
+    public void testCanFetchAllAccountKeysAtSpecificBlockHeight() {
+        FlowAddress address = serviceAccount.getFlowAddress();
+
+        FlowAccessApi.AccessApiCallResponse<FlowBlock> latestBlockResponse = accessAPI.getLatestBlock(true, false);
+
+        if (latestBlockResponse instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            FlowBlock latestBlock = ((FlowAccessApi.AccessApiCallResponse.Success<FlowBlock>) latestBlockResponse).getData();
+            List<FlowAccountKey> accountKeys = keysAPIConnector.getAccountKeysAtBlockHeight(address, latestBlock.getHeight());
+
+            Assertions.assertNotNull(accountKeys, "Account keys list at specific block height should not be null");
+            Assertions.assertFalse(accountKeys.isEmpty(), "Account keys list at specific block height should not be empty");
+            accountKeys.forEach(key -> Assertions.assertTrue(key.getWeight() > 0, "Each account key weight should be positive"));
+        } else if (latestBlockResponse instanceof FlowAccessApi.AccessApiCallResponse.Error error) {
+            throw new RuntimeException("Failed to retrieve the latest block: " + error.getMessage(), error.getThrowable());
+        }
+    }
+
+    @Test
+    public void testAccountKeysMatchAtLatestBlockAndSpecificBlockHeight() {
+        FlowAddress address = serviceAccount.getFlowAddress();
+
+        List<FlowAccountKey> keysAtLatestBlock = keysAPIConnector.getAccountKeysAtLatestBlock(address);
+
+        FlowAccessApi.AccessApiCallResponse<FlowBlock> latestBlockResponse = accessAPI.getLatestBlock(true, false);
+
+        if (latestBlockResponse instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            FlowBlock latestBlock = ((FlowAccessApi.AccessApiCallResponse.Success<FlowBlock>) latestBlockResponse).getData();
+            List<FlowAccountKey> keysAtSpecificHeight = keysAPIConnector.getAccountKeysAtBlockHeight(address, latestBlock.getHeight());
+
+            Assertions.assertEquals(keysAtLatestBlock.size(), keysAtSpecificHeight.size(), "Number of account keys should match at latest block and specific block height");
+
+            for (int i = 0; i < keysAtLatestBlock.size(); i++) {
+                Assertions.assertEquals(keysAtLatestBlock.get(i), keysAtSpecificHeight.get(i), "Account key at index " + i + " should match between latest block and specific block height");
+            }
+        } else if (latestBlockResponse instanceof FlowAccessApi.AccessApiCallResponse.Error error) {
+            throw new RuntimeException("Failed to retrieve the latest block: " + error.getMessage(), error.getThrowable());
+        }
+    }
+}

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -81,6 +81,7 @@ Below is a list of all Kotlin code examples currently supported in this repo:
 
 - Get transaction 
 - Get transaction result
+- Get transaction result by index
 
 #### Sending Transactions
 

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -54,6 +54,10 @@ Below is a list of all Kotlin code examples currently supported in this repo:
 - Get account balance
 - Get account from the latest block
 - Get account from block by height
+- Get account key at latest block
+- Get account keys at latest block
+- Get account key at block height
+- Get account keys at block height
 
 #### Get Events
 

--- a/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getAccountKeys/GetAccountKeysAccessAPIConnector.kt
+++ b/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getAccountKeys/GetAccountKeysAccessAPIConnector.kt
@@ -1,0 +1,31 @@
+package org.onflow.examples.kotlin.getAccountKeys
+
+import org.onflow.flow.sdk.*
+
+internal class GetAccountKeysAccessAPIConnector(
+    private val accessAPI: FlowAccessApi
+) {
+    fun getAccountKeyAtLatestBlock(address: FlowAddress, keyIndex: Int): FlowAccountKey =
+        when (val response = accessAPI.getAccountKeyAtLatestBlock(address, keyIndex)) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
+
+    fun getAccountKeyAtBlockHeight(address: FlowAddress, keyIndex: Int, height: Long): FlowAccountKey =
+        when (val response = accessAPI.getAccountKeyAtBlockHeight(address, keyIndex, height)) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
+
+    fun getAccountKeysAtLatestBlock(address: FlowAddress): List<FlowAccountKey> =
+        when (val response = accessAPI.getAccountKeysAtLatestBlock(address)) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
+
+    fun getAccountKeysAtBlockHeight(address: FlowAddress, height: Long): List<FlowAccountKey> =
+        when (val response = accessAPI.getAccountKeysAtBlockHeight(address, height)) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
+}

--- a/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnector.kt
+++ b/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnector.kt
@@ -16,4 +16,10 @@ class GetTransactionAccessAPIConnector(
             is FlowAccessApi.AccessApiCallResponse.Success -> response.data
             is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
         }
+
+    fun getTransactionResultByIndex(blockId: FlowId, index: Int): FlowTransactionResult =
+        when (val response = accessAPI.getTransactionResultByIndex(blockId, index)) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
 }

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getAccountKeys/GetAccountKeysAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getAccountKeys/GetAccountKeysAccessAPIConnectorTest.kt
@@ -1,0 +1,103 @@
+package org.onflow.examples.kotlin.getAccountKeys
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.onflow.flow.common.test.FlowEmulatorProjectTest
+import org.onflow.flow.common.test.FlowServiceAccountCredentials
+import org.onflow.flow.common.test.FlowTestClient
+import org.onflow.flow.common.test.TestAccount
+import org.onflow.flow.sdk.FlowAccessApi
+
+@FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
+internal class GetAccountKeysAccessAPIConnectorTest {
+    @FlowServiceAccountCredentials
+    lateinit var serviceAccount: TestAccount
+
+    @FlowTestClient
+    lateinit var accessAPI: FlowAccessApi
+
+    private lateinit var keysAPIConnector: GetAccountKeysAccessAPIConnector
+
+    @BeforeEach
+    fun setup() {
+        keysAPIConnector = GetAccountKeysAccessAPIConnector(accessAPI)
+    }
+
+    @Test
+    fun `Can fetch account key at latest block`() {
+        val address = serviceAccount.flowAddress
+        val keyIndex = 0
+
+        val accountKey = keysAPIConnector.getAccountKeyAtLatestBlock(address, keyIndex)
+
+        Assertions.assertNotNull(accountKey, "Account key should not be null")
+        Assertions.assertEquals(keyIndex, accountKey.sequenceNumber, "Account key index should match requested index")
+    }
+
+    @Test
+    fun `Can fetch account key at a specific block height`() {
+        val address = serviceAccount.flowAddress
+        val keyIndex = 0
+        when (val latestBlock = accessAPI.getLatestBlock(true)) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> {
+                val accountKey = keysAPIConnector.getAccountKeyAtBlockHeight(address, keyIndex, latestBlock.data.height)
+
+                Assertions.assertNotNull(accountKey, "Account key at specific block height should not be null")
+                Assertions.assertEquals(keyIndex, accountKey.sequenceNumber, "Account key index at specific block height should match requested index")
+            }
+            is FlowAccessApi.AccessApiCallResponse.Error -> Assertions.fail("Failed to retrieve the latest block: ${latestBlock.message}")
+        }
+    }
+
+    @Test
+    fun `Can fetch all account keys at latest block`() {
+        val address = serviceAccount.flowAddress
+        val accountKeys = keysAPIConnector.getAccountKeysAtLatestBlock(address)
+
+        Assertions.assertNotNull(accountKeys, "Account keys should not be null")
+        Assertions.assertTrue(accountKeys.isNotEmpty(), "Account keys should not be empty")
+    }
+
+    @Test
+    fun `Can fetch all account keys at a specific block height`() {
+        val address = serviceAccount.flowAddress
+        val latestBlock = accessAPI.getLatestBlock(true)
+
+        when (latestBlock) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> {
+                val accountKeys = keysAPIConnector.getAccountKeysAtBlockHeight(address, latestBlock.data.height)
+
+                Assertions.assertNotNull(accountKeys, "Account keys at specific block height should not be null")
+                Assertions.assertTrue(accountKeys.isNotEmpty(), "Account keys at specific block height should not be empty")
+            }
+            is FlowAccessApi.AccessApiCallResponse.Error -> Assertions.fail("Failed to retrieve the latest block: ${latestBlock.message}")
+        }
+    }
+
+    @Test
+    fun `Account keys at the latest block and specific block height should match`() {
+        val address = serviceAccount.flowAddress
+
+        // Fetch account keys at latest block
+        val keysAtLatest = keysAPIConnector.getAccountKeysAtLatestBlock(address)
+
+        // Fetch latest block height
+        val latestBlock = accessAPI.getLatestBlock(true)
+        when (latestBlock) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> {
+                val blockHeight = latestBlock.data.height
+
+                // Fetch account keys at the same block height
+                val keysAtHeight = keysAPIConnector.getAccountKeysAtBlockHeight(address, blockHeight)
+
+                Assertions.assertEquals(keysAtLatest.size, keysAtHeight.size, "Number of account keys should match at latest block and specific block height")
+
+                keysAtLatest.forEachIndexed { index, key ->
+                    Assertions.assertEquals(key, keysAtHeight[index], "Account key at index $index should match between latest block and specific block height")
+                }
+            }
+            is FlowAccessApi.AccessApiCallResponse.Error -> Assertions.fail("Failed to retrieve the latest block: ${latestBlock.message}")
+        }
+    }
+}

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnectorTest.kt
@@ -20,6 +20,7 @@ internal class GetTransactionAccessAPIConnectorTest {
     lateinit var accessAPI: FlowAccessApi
 
     private lateinit var connector: GetTransactionAccessAPIConnector
+    private lateinit var block: FlowBlock
     private lateinit var accessAPIConnector: AccessAPIConnector
 
     private lateinit var txID: FlowId
@@ -35,6 +36,11 @@ internal class GetTransactionAccessAPIConnectorTest {
             serviceAccount.flowAddress,
             publicKey
         )
+
+        block = when (val response = accessAPI.getLatestBlock()) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
     }
 
     @Test
@@ -48,6 +54,14 @@ internal class GetTransactionAccessAPIConnectorTest {
     @Test
     fun `Can fetch a transaction result`() {
         val transactionResult = connector.getTransactionResult(txID)
+
+        assertNotNull(transactionResult, "Transaction result should not be null")
+        assertTrue(transactionResult.status === FlowTransactionStatus.SEALED, "Transaction should be sealed")
+    }
+
+    @Test
+    fun `Can fetch a transaction result by index`() {
+        val transactionResult = connector.getTransactionResultByIndex(block.id, 0)
 
         assertNotNull(transactionResult, "Transaction result should not be null")
         assertTrue(transactionResult.status === FlowTransactionStatus.SEALED, "Transaction should be sealed")

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -56,6 +56,94 @@ class TransactionIntegrationTest {
     }
 
     @Test
+    fun `Can get account key at latest block`() {
+        val address = serviceAccount.flowAddress
+        val keyIndex = 0
+
+        val accountKey = try {
+            handleResult(
+                accessAPI.getAccountKeyAtLatestBlock(address, keyIndex),
+                "Failed to get account key at latest block"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve account key at latest block: ${e.message}")
+        }
+
+        assertThat(accountKey).isNotNull
+        assertThat(accountKey.sequenceNumber).isEqualTo(keyIndex)
+    }
+
+    @Test
+    fun `Can get account key at block height`() {
+        val address = serviceAccount.flowAddress
+        val keyIndex = 0
+
+        val latestBlock = try {
+            handleResult(
+                accessAPI.getLatestBlock(true),
+                "Failed to get latest block"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve latest block: ${e.message}")
+        }
+
+        val accountKey = try {
+            handleResult(
+                accessAPI.getAccountKeyAtBlockHeight(address, keyIndex, latestBlock.height),
+                "Failed to get account key at block height"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve account key at block height: ${e.message}")
+        }
+
+        assertThat(accountKey).isNotNull
+        assertThat(accountKey.sequenceNumber).isEqualTo(keyIndex)
+    }
+
+    @Test
+    fun `Can get account keys at latest block`() {
+        val address = serviceAccount.flowAddress
+
+        val accountKeys = try {
+            handleResult(
+                accessAPI.getAccountKeysAtLatestBlock(address),
+                "Failed to get account keys at latest block"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve account keys at latest block: ${e.message}")
+        }
+
+        assertThat(accountKeys).isNotNull
+        assertThat(accountKeys).isNotEmpty
+    }
+
+    @Test
+    fun `Can get account keys at block height`() {
+        val address = serviceAccount.flowAddress
+
+        val latestBlock = try {
+            handleResult(
+                accessAPI.getLatestBlock(true),
+                "Failed to get latest block"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve latest block: ${e.message}")
+        }
+
+        val accountKeys = try {
+            handleResult(
+                accessAPI.getAccountKeysAtBlockHeight(address, latestBlock.height),
+                "Failed to get account keys at block height"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve account keys at block height: ${e.message}")
+        }
+
+        assertThat(accountKeys).isNotNull
+        assertThat(accountKeys).isNotEmpty
+    }
+
+    @Test
     fun `Can get node version info`() {
         val nodeVersionInfo = try {
             handleResult(

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -162,13 +162,58 @@ class TransactionIntegrationTest {
     }
 
     @Test
+    fun `Can get transaction results`() {
+        val txResult = createAndSubmitAccountCreationTransaction(
+            accessAPI,
+            serviceAccount,
+            "cadence/transaction_creation/transaction_creation_simple_transaction.cdc"
+        )
+        assertThat(txResult).isNotNull
+        assertThat(txResult.status).isEqualTo(FlowTransactionStatus.SEALED)
+
+        val latestBlock = try {
+            handleResult(
+                accessAPI.getLatestBlock(true),
+                "Failed to get latest block"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve latest block: ${e.message}")
+        }
+
+        val txResultById = try {
+            handleResult(
+                accessAPI.getTransactionResultById(txResult.transactionId),
+                "Failed to get tx result by id"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve tx result by id: ${e.message}")
+        }
+
+        assertThat(txResultById).isNotNull
+        assertThat(txResultById.status).isEqualTo(FlowTransactionStatus.SEALED)
+        assertThat(txResultById.transactionId).isEqualTo(txResult.transactionId)
+
+        val txResultByIndex = try {
+            handleResult(
+                accessAPI.getTransactionResultByIndex(latestBlock.id, 0),
+                "Failed to get tx result by index"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve tx result by index: ${e.message}")
+        }
+
+        assertThat(txResultByIndex).isNotNull
+        assertThat(txResultByIndex.status).isEqualTo(FlowTransactionStatus.SEALED)
+        assertThat(txResultByIndex.transactionId).isEqualTo(txResultByIndex.transactionId)
+    }
+
+    @Test
     fun `Can parse events`() {
         val txResult = createAndSubmitAccountCreationTransaction(
             accessAPI,
             serviceAccount,
             "cadence/transaction_creation/transaction_creation_simple_transaction.cdc"
         )
-
         assertThat(txResult).isNotNull
         assertThat(txResult.status).isEqualTo(FlowTransactionStatus.SEALED)
 

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -204,7 +204,7 @@ class TransactionIntegrationTest {
 
         assertThat(txResultByIndex).isNotNull
         assertThat(txResultByIndex.status).isEqualTo(FlowTransactionStatus.SEALED)
-        assertThat(txResultByIndex.transactionId).isEqualTo(txResultByIndex.transactionId)
+        assertThat(txResultByIndex.transactionId).isEqualTo(txResult.transactionId)
     }
 
     @Test

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
@@ -38,7 +38,7 @@ interface AsyncFlowAccessApi {
 
     fun getTransactionResultById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult?>>
 
-    fun getTransactionResultByIndex(blockId: FlowId, index: Int) : CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>>
+    fun getTransactionResultByIndex(blockId: FlowId, index: Int): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>>
 
     @Deprecated(
         message = "Behaves identically to getAccountAtLatestBlock",

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
@@ -38,7 +38,7 @@ interface AsyncFlowAccessApi {
 
     fun getTransactionResultById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult?>>
 
-    fun getTransactionResultByIndex(blockId: FlowId, index: Int):  CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>>
+    fun getTransactionResultByIndex(blockId: FlowId, index: Int) : CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>>
 
     @Deprecated(
         message = "Behaves identically to getAccountAtLatestBlock",

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
@@ -6,6 +6,14 @@ import java.util.concurrent.CompletableFuture
 interface AsyncFlowAccessApi {
     fun ping(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<Unit>>
 
+    fun getAccountKeyAtLatestBlock(address: FlowAddress, keyIndex: Int): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccountKey>>
+
+    fun getAccountKeyAtBlockHeight(address: FlowAddress, keyIndex: Int, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccountKey>>
+
+    fun getAccountKeysAtLatestBlock(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>>>
+
+    fun getAccountKeysAtBlockHeight(address: FlowAddress, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>>>
+
     fun getLatestBlockHeader(sealed: Boolean = true): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlockHeader>>
 
     fun getBlockHeaderById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlockHeader?>>

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
@@ -38,6 +38,8 @@ interface AsyncFlowAccessApi {
 
     fun getTransactionResultById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult?>>
 
+    fun getTransactionResultByIndex(blockId: FlowId, index: Int):  CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>>
+
     @Deprecated(
         message = "Behaves identically to getAccountAtLatestBlock",
         replaceWith = ReplaceWith("getAccountAtLatestBlock")

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
@@ -50,6 +50,8 @@ interface FlowAccessApi {
 
     fun getTransactionResultById(id: FlowId): AccessApiCallResponse<FlowTransactionResult>
 
+    fun getTransactionResultByIndex(blockId: FlowId, index: Int): AccessApiCallResponse<FlowTransactionResult>
+
     @Deprecated(
         message = "Behaves identically to getAccountAtLatestBlock",
         replaceWith = ReplaceWith("getAccountAtLatestBlock")

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
@@ -18,6 +18,14 @@ interface FlowAccessApi {
 
     fun ping(): AccessApiCallResponse<Unit>
 
+    fun getAccountKeyAtLatestBlock(address: FlowAddress, keyIndex: Int): AccessApiCallResponse<FlowAccountKey>
+
+    fun getAccountKeyAtBlockHeight(address: FlowAddress, keyIndex: Int, height: Long): AccessApiCallResponse<FlowAccountKey>
+
+    fun getAccountKeysAtLatestBlock(address: FlowAddress): AccessApiCallResponse<List<FlowAccountKey>>
+
+    fun getAccountKeysAtBlockHeight(address: FlowAddress, height: Long): AccessApiCallResponse<List<FlowAccountKey>>
+
     fun getLatestBlockHeader(sealed: Boolean = true): AccessApiCallResponse<FlowBlockHeader>
 
     fun getBlockHeaderById(id: FlowId): AccessApiCallResponse<FlowBlockHeader>
@@ -27,6 +35,7 @@ interface FlowAccessApi {
     fun getLatestBlock(sealed: Boolean = true, fullBlockResponse: Boolean = false): AccessApiCallResponse<FlowBlock>
 
     fun getBlockById(id: FlowId, fullBlockResponse: Boolean = false): AccessApiCallResponse<FlowBlock>
+
     fun getAccountBalanceAtLatestBlock(address: FlowAddress): AccessApiCallResponse<Long>
 
     fun getAccountBalanceAtBlockHeight(address: FlowAddress, height: Long): AccessApiCallResponse<Long>

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -43,6 +43,110 @@ class AsyncFlowAccessApiImpl(
         }
     }
 
+    override fun getAccountKeyAtLatestBlock(address: FlowAddress, keyIndex: Int): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccountKey>> {
+        return try {
+            completableFuture(
+                try {
+                    api.getAccountKeyAtLatestBlock(
+                        Access.GetAccountKeyAtLatestBlockRequest
+                            .newBuilder()
+                            .setAddress(address.byteStringValue)
+                            .setIndex(keyIndex)
+                            .build()
+                    )
+                } catch (e: Exception) {
+                    return CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at latest block", e))
+                }
+            ).handle { response, ex ->
+                if (ex != null) {
+                    FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at latest block", ex)
+                } else {
+                    FlowAccessApi.AccessApiCallResponse.Success(FlowAccountKey.of(response.accountKey ))
+                }
+            }
+        } catch (e: Exception) {
+            CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at latest block", e))
+        }
+    }
+
+    override fun getAccountKeyAtBlockHeight(address: FlowAddress, keyIndex: Int, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccountKey>> {
+        return try {
+            completableFuture(
+                try {
+                    api.getAccountKeyAtBlockHeight(
+                        Access.GetAccountKeyAtBlockHeightRequest
+                            .newBuilder()
+                            .setAddress(address.byteStringValue)
+                            .setIndex(keyIndex)
+                            .setBlockHeight(height)
+                            .build()
+                    )
+                } catch (e: Exception) {
+                    return CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at block height", e))
+                }
+            ).handle { response, ex ->
+                if (ex != null) {
+                    FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at block height", ex)
+                } else {
+                    FlowAccessApi.AccessApiCallResponse.Success(FlowAccountKey.of(response.accountKey ))
+                }
+            }
+        } catch (e: Exception) {
+            CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at block height", e))
+        }
+    }
+
+    override fun getAccountKeysAtLatestBlock(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>>> {
+        return try {
+            completableFuture(
+                try {
+                    api.getAccountKeysAtLatestBlock(
+                        Access.GetAccountKeysAtLatestBlockRequest
+                            .newBuilder()
+                            .setAddress(address.byteStringValue)
+                            .build()
+                    )
+                } catch (e: Exception) {
+                    return CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at latest block", e))
+                }
+            ).handle { response, ex ->
+                if (ex != null) {
+                    FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at latest block", ex)
+                } else {
+                    FlowAccessApi.AccessApiCallResponse.Success(response.accountKeysList.map { FlowAccountKey.of(it) })
+                }
+            }
+        } catch (e: Exception) {
+            CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at latest block", e))
+        }
+    }
+
+    override fun getAccountKeysAtBlockHeight(address: FlowAddress, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>>> {
+        return try {
+            completableFuture(
+                try {
+                    api.getAccountKeysAtBlockHeight(
+                        Access.GetAccountKeysAtBlockHeightRequest
+                            .newBuilder()
+                            .setAddress(address.byteStringValue)
+                            .setBlockHeight(height)
+                            .build()
+                    )
+                } catch (e: Exception) {
+                    return CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at block height", e))
+                }
+            ).handle { response, ex ->
+                if (ex != null) {
+                    FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at block height", ex)
+                } else {
+                    FlowAccessApi.AccessApiCallResponse.Success(response.accountKeysList.map { FlowAccountKey.of(it) })
+                }
+            }
+        } catch (e: Exception) {
+            CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at block height", e))
+        }
+    }
+
     override fun getLatestBlockHeader(sealed: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlockHeader>> {
         return try {
             completableFuture(

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -61,7 +61,7 @@ class AsyncFlowAccessApiImpl(
                 if (ex != null) {
                     FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at latest block", ex)
                 } else {
-                    FlowAccessApi.AccessApiCallResponse.Success(FlowAccountKey.of(response.accountKey ))
+                    FlowAccessApi.AccessApiCallResponse.Success(FlowAccountKey.of(response.accountKey))
                 }
             }
         } catch (e: Exception) {
@@ -88,7 +88,7 @@ class AsyncFlowAccessApiImpl(
                 if (ex != null) {
                     FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at block height", ex)
                 } else {
-                    FlowAccessApi.AccessApiCallResponse.Success(FlowAccountKey.of(response.accountKey ))
+                    FlowAccessApi.AccessApiCallResponse.Success(FlowAccountKey.of(response.accountKey))
                 }
             }
         } catch (e: Exception) {

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -476,6 +476,32 @@ class AsyncFlowAccessApiImpl(
         }
     }
 
+    override fun getTransactionResultByIndex(blockId: FlowId, index: Int): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>> {
+        return try {
+            completableFuture(
+                try {
+                    api.getTransactionResultByIndex(
+                        Access.GetTransactionByIndexRequest
+                            .newBuilder()
+                            .setBlockId(blockId.byteStringValue)
+                            .setIndex(index)
+                            .build()
+                    )
+                } catch (e: Exception) {
+                    return CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by index", e))
+                }
+            ).handle { response, ex ->
+                if (ex != null) {
+                    FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by index", ex)
+                } else {
+                    FlowAccessApi.AccessApiCallResponse.Success(FlowTransactionResult.of(response))
+                }
+            }
+        } catch (e: Exception) {
+            CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by index", e))
+        }
+    }
+
     @Deprecated("Behaves identically to getAccountAtLatestBlock", replaceWith = ReplaceWith("getAccountAtLatestBlock"))
     override fun getAccountByAddress(addresss: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> {
         return try {

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
@@ -276,7 +276,6 @@ class FlowAccessApiImpl(
             FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by ID", e)
         }
 
-
     override fun getTransactionResultByIndex(blockId: FlowId, index: Int): FlowAccessApi.AccessApiCallResponse<FlowTransactionResult> =
         try {
             val ret = api.getTransactionResultByIndex(

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
@@ -78,7 +78,6 @@ class FlowAccessApiImpl(
             FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at latest block", e)
         }
 
-
     override fun getAccountKeysAtBlockHeight(address: FlowAddress, height: Long): FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>> =
         try {
             val ret = api.getAccountKeysAtBlockHeight(
@@ -92,7 +91,6 @@ class FlowAccessApiImpl(
         } catch (e: Exception) {
             FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at block height", e)
         }
-
 
     override fun getLatestBlockHeader(sealed: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlockHeader> =
         try {

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
@@ -36,6 +36,64 @@ class FlowAccessApiImpl(
             FlowAccessApi.AccessApiCallResponse.Error("Failed to ping", e)
         }
 
+    override fun getAccountKeyAtLatestBlock(address: FlowAddress, keyIndex: Int): FlowAccessApi.AccessApiCallResponse<FlowAccountKey> =
+        try {
+            val ret = api.getAccountKeyAtLatestBlock(
+                Access.GetAccountKeyAtLatestBlockRequest
+                    .newBuilder()
+                    .setAddress(address.byteStringValue)
+                    .setIndex(keyIndex)
+                    .build()
+            )
+            FlowAccessApi.AccessApiCallResponse.Success(FlowAccountKey.of(ret.accountKey))
+        } catch (e: Exception) {
+            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at latest block", e)
+        }
+
+    override fun getAccountKeyAtBlockHeight(address: FlowAddress, keyIndex: Int, height: Long): FlowAccessApi.AccessApiCallResponse<FlowAccountKey> =
+        try {
+            val ret = api.getAccountKeyAtBlockHeight(
+                Access.GetAccountKeyAtBlockHeightRequest
+                    .newBuilder()
+                    .setAddress(address.byteStringValue)
+                    .setIndex(keyIndex)
+                    .setBlockHeight(height)
+                    .build()
+            )
+            FlowAccessApi.AccessApiCallResponse.Success(FlowAccountKey.of(ret.accountKey))
+        } catch (e: Exception) {
+            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at block height", e)
+        }
+
+    override fun getAccountKeysAtLatestBlock(address: FlowAddress): FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>> =
+        try {
+            val ret = api.getAccountKeysAtLatestBlock(
+                Access.GetAccountKeysAtLatestBlockRequest
+                    .newBuilder()
+                    .setAddress(address.byteStringValue)
+                    .build()
+            )
+            FlowAccessApi.AccessApiCallResponse.Success(ret.accountKeysList.map { FlowAccountKey.of(it) })
+        } catch (e: Exception) {
+            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at latest block", e)
+        }
+
+
+    override fun getAccountKeysAtBlockHeight(address: FlowAddress, height: Long): FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>> =
+        try {
+            val ret = api.getAccountKeysAtBlockHeight(
+                Access.GetAccountKeysAtBlockHeightRequest
+                    .newBuilder()
+                    .setAddress(address.byteStringValue)
+                    .setBlockHeight(height)
+                    .build()
+            )
+            FlowAccessApi.AccessApiCallResponse.Success(ret.accountKeysList.map { FlowAccountKey.of(it) })
+        } catch (e: Exception) {
+            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at block height", e)
+        }
+
+
     override fun getLatestBlockHeader(sealed: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlockHeader> =
         try {
             val ret = api.getLatestBlockHeader(

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
@@ -276,6 +276,21 @@ class FlowAccessApiImpl(
             FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by ID", e)
         }
 
+
+    override fun getTransactionResultByIndex(blockId: FlowId, index: Int): FlowAccessApi.AccessApiCallResponse<FlowTransactionResult> =
+        try {
+            val ret = api.getTransactionResultByIndex(
+                Access.GetTransactionByIndexRequest
+                    .newBuilder()
+                    .setBlockId(blockId.byteStringValue)
+                    .setIndex(index)
+                    .build()
+            )
+            FlowAccessApi.AccessApiCallResponse.Success(FlowTransactionResult.of(ret))
+        } catch (e: Exception) {
+            FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by index", e)
+        }
+
     @Deprecated("Behaves identically to getAccountAtLatestBlock", replaceWith = ReplaceWith("getAccountAtLatestBlock"))
     override fun getAccountByAddress(addresss: FlowAddress): FlowAccessApi.AccessApiCallResponse<FlowAccount> =
         try {

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
@@ -19,6 +19,72 @@ import org.onflow.protobuf.entities.TransactionOuterClass
 
 class FlowAccessApiTest {
     @Test
+    fun `Test getAccountKeyAtLatestBlock`() {
+        val flowAccessApi = mock(FlowAccessApi::class.java)
+        val address = FlowAddress("01")
+        val keyIndex = 0
+        val accountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+
+        `when`(flowAccessApi.getAccountKeyAtLatestBlock(address, keyIndex)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(accountKey))
+
+        val result = flowAccessApi.getAccountKeyAtLatestBlock(address, keyIndex)
+
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(accountKey), result)
+        verify(flowAccessApi).getAccountKeyAtLatestBlock(address, keyIndex)
+    }
+
+    @Test
+    fun `Test getAccountKeyAtBlockHeight`() {
+        val flowAccessApi = mock(FlowAccessApi::class.java)
+        val address = FlowAddress("01")
+        val keyIndex = 0
+        val height = 123L
+        val accountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+
+        `when`(flowAccessApi.getAccountKeyAtBlockHeight(address, keyIndex, height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(accountKey))
+
+        val result = flowAccessApi.getAccountKeyAtBlockHeight(address, keyIndex, height)
+
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(accountKey), result)
+        verify(flowAccessApi).getAccountKeyAtBlockHeight(address, keyIndex, height)
+    }
+
+    @Test
+    fun `Test getAccountKeysAtLatestBlock`() {
+        val flowAccessApi = mock(FlowAccessApi::class.java)
+        val address = FlowAddress("01")
+        val accountKeys = listOf(
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        )
+
+        `when`(flowAccessApi.getAccountKeysAtLatestBlock(address)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(accountKeys))
+
+        val result = flowAccessApi.getAccountKeysAtLatestBlock(address)
+
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(accountKeys), result)
+        verify(flowAccessApi).getAccountKeysAtLatestBlock(address)
+    }
+
+    @Test
+    fun `Test getAccountKeysAtBlockHeight`() {
+        val flowAccessApi = mock(FlowAccessApi::class.java)
+        val address = FlowAddress("01")
+        val height = 123L
+        val accountKeys = listOf(
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        )
+
+        `when`(flowAccessApi.getAccountKeysAtBlockHeight(address, height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(accountKeys))
+
+        val result = flowAccessApi.getAccountKeysAtBlockHeight(address, height)
+
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(accountKeys), result)
+        verify(flowAccessApi).getAccountKeysAtBlockHeight(address, height)
+    }
+
+    @Test
     fun `Test getLatestBlockHeader`() {
         val flowAccessApi = mock(FlowAccessApi::class.java)
         val latestBlockHeader = FlowBlockHeader.of(BlockHeaderOuterClass.BlockHeader.getDefaultInstance())

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
@@ -265,6 +265,20 @@ class FlowAccessApiTest {
     }
 
     @Test
+    fun `Test getTransactionResultByIndex`() {
+        val flowAccessApi = mock(FlowAccessApi::class.java)
+        val flowId = FlowId("01")
+        val index = 0
+
+        val flowTransactionResult = FlowTransactionResult.of(Access.TransactionResultResponse.getDefaultInstance())
+        `when`(flowAccessApi.getTransactionResultByIndex(flowId, index)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowTransactionResult))
+
+        val result = flowAccessApi.getTransactionResultByIndex(flowId, index)
+
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(flowTransactionResult), result)
+    }
+
+    @Test
     fun `Test getAccountAtLatestBlock`() {
         val flowAccessApi = mock(FlowAccessApi::class.java)
         val flowAddress = FlowAddress("01")

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -13,6 +13,7 @@ import org.mockito.Mockito.`when`
 import org.onflow.flow.sdk.*
 import org.onflow.protobuf.access.Access
 import org.onflow.protobuf.access.AccessAPIGrpc
+import org.onflow.protobuf.entities.AccountOuterClass
 import org.onflow.protobuf.entities.ExecutionResultOuterClass
 import org.onflow.protobuf.entities.NodeVersionInfoOuterClass
 import org.onflow.protobuf.entities.TransactionOuterClass
@@ -73,6 +74,136 @@ class AsyncFlowAccessApiImplTest {
 
         val result = asyncFlowAccessApi.ping().get()
         assert(result is FlowAccessApi.AccessApiCallResponse.Success)
+    }
+
+    @Test
+    fun `test getAccountKeyAtLatestBlock success`() {
+        val flowAddress = FlowAddress("01")
+        val keyIndex = 0
+        val mockAccountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        val response = Access.AccountKeyResponse.newBuilder().setAccountKey(mockAccountKey.builder().build()).build()
+
+        `when`(api.getAccountKeyAtLatestBlock(any())).thenReturn(setupFutureMock(response))
+
+        val result = asyncFlowAccessApi.getAccountKeyAtLatestBlock(flowAddress, keyIndex).get()
+        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
+        result as FlowAccessApi.AccessApiCallResponse.Success
+        assertEquals(mockAccountKey, result.data)
+    }
+
+    @Test
+    fun `test getAccountKeyAtLatestBlock failure`() {
+        val flowAddress = FlowAddress("01")
+        val keyIndex = 0
+        val exception = RuntimeException("Test exception")
+
+        `when`(api.getAccountKeyAtLatestBlock(any())).thenThrow(exception)
+
+        val result = asyncFlowAccessApi.getAccountKeyAtLatestBlock(flowAddress, keyIndex).get()
+        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
+        result as FlowAccessApi.AccessApiCallResponse.Error
+        assertEquals("Failed to get account key at latest block", result.message)
+        assertEquals(exception, result.throwable)
+    }
+
+    @Test
+    fun `test getAccountKeyAtBlockHeight success`() {
+        val flowAddress = FlowAddress("01")
+        val keyIndex = 0
+        val blockHeight = HEIGHT
+        val mockAccountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        val response = Access.AccountKeyResponse.newBuilder().setAccountKey(mockAccountKey.builder().build()).build()
+
+        `when`(api.getAccountKeyAtBlockHeight(any())).thenReturn(setupFutureMock(response))
+
+        val result = asyncFlowAccessApi.getAccountKeyAtBlockHeight(flowAddress, keyIndex, blockHeight).get()
+        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
+        result as FlowAccessApi.AccessApiCallResponse.Success
+        assertEquals(mockAccountKey, result.data)
+    }
+
+    @Test
+    fun `test getAccountKeyAtBlockHeight failure`() {
+        val flowAddress = FlowAddress("01")
+        val keyIndex = 0
+        val blockHeight = HEIGHT
+        val exception = RuntimeException("Test exception")
+
+        `when`(api.getAccountKeyAtBlockHeight(any())).thenThrow(exception)
+
+        val result = asyncFlowAccessApi.getAccountKeyAtBlockHeight(flowAddress, keyIndex, blockHeight).get()
+        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
+        result as FlowAccessApi.AccessApiCallResponse.Error
+        assertEquals("Failed to get account key at block height", result.message)
+        assertEquals(exception, result.throwable)
+    }
+
+    @Test
+    fun `test getAccountKeysAtLatestBlock success`() {
+        val flowAddress = FlowAddress("01")
+        val mockAccountKeys = listOf(
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        )
+        val response = Access.AccountKeysResponse.newBuilder()
+            .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
+            .build()
+
+        `when`(api.getAccountKeysAtLatestBlock(any())).thenReturn(setupFutureMock(response))
+
+        val result = asyncFlowAccessApi.getAccountKeysAtLatestBlock(flowAddress).get()
+        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
+        result as FlowAccessApi.AccessApiCallResponse.Success
+        assertEquals(mockAccountKeys, result.data)
+    }
+
+    @Test
+    fun `test getAccountKeysAtLatestBlock failure`() {
+        val flowAddress = FlowAddress("01")
+        val exception = RuntimeException("Test exception")
+
+        `when`(api.getAccountKeysAtLatestBlock(any())).thenThrow(exception)
+
+        val result = asyncFlowAccessApi.getAccountKeysAtLatestBlock(flowAddress).get()
+        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
+        result as FlowAccessApi.AccessApiCallResponse.Error
+        assertEquals("Failed to get account keys at latest block", result.message)
+        assertEquals(exception, result.throwable)
+    }
+
+    @Test
+    fun `test getAccountKeysAtBlockHeight success`() {
+        val flowAddress = FlowAddress("01")
+        val blockHeight = HEIGHT
+        val mockAccountKeys = listOf(
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        )
+        val response = Access.AccountKeysResponse.newBuilder()
+            .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
+            .build()
+
+        `when`(api.getAccountKeysAtBlockHeight(any())).thenReturn(setupFutureMock(response))
+
+        val result = asyncFlowAccessApi.getAccountKeysAtBlockHeight(flowAddress, blockHeight).get()
+        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
+        result as FlowAccessApi.AccessApiCallResponse.Success
+        assertEquals(mockAccountKeys, result.data)
+    }
+
+    @Test
+    fun `test getAccountKeysAtBlockHeight failure`() {
+        val flowAddress = FlowAddress("01")
+        val blockHeight = HEIGHT
+        val exception = RuntimeException("Test exception")
+
+        `when`(api.getAccountKeysAtBlockHeight(any())).thenThrow(exception)
+
+        val result = asyncFlowAccessApi.getAccountKeysAtBlockHeight(flowAddress, blockHeight).get()
+        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
+        result as FlowAccessApi.AccessApiCallResponse.Error
+        assertEquals("Failed to get account keys at block height", result.message)
+        assertEquals(exception, result.throwable)
     }
 
     @Test

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -93,19 +93,29 @@ class AsyncFlowAccessApiImplTest {
 
     private object MockResponseFactory {
         fun accountKeyResponse(accountKey: FlowAccountKey) = Access.AccountKeyResponse
-            .newBuilder().setAccountKey(accountKey.builder().build()).build()
+            .newBuilder()
+            .setAccountKey(accountKey.builder().build())
+            .build()
 
         fun accountKeysResponse(accountKeys: List<FlowAccountKey>) = Access.AccountKeysResponse
-            .newBuilder().addAllAccountKeys(accountKeys.map { it.builder().build() }).build()
+            .newBuilder()
+            .addAllAccountKeys(accountKeys.map { it.builder().build() })
+            .build()
 
         fun accountBalanceResponse(balance: Long) = Access.AccountBalanceResponse
-            .newBuilder().setBalance(balance).build()
+            .newBuilder()
+            .setBalance(balance)
+            .build()
 
         fun blockHeaderResponse(mockBlockHeader: FlowBlockHeader) = Access.BlockHeaderResponse
-            .newBuilder().setBlock(mockBlockHeader.builder().build()).build()
+            .newBuilder()
+            .setBlock(mockBlockHeader.builder().build())
+            .build()
 
         fun blockResponse(mockBlock: FlowBlock) = Access.BlockResponse
-            .newBuilder().setBlock(mockBlock.builder().build()).build()
+            .newBuilder()
+            .setBlock(mockBlock.builder().build())
+            .build()
 
         fun collectionResponse(mockCollection: FlowCollection) = Access.CollectionResponse
             .newBuilder()
@@ -121,7 +131,6 @@ class AsyncFlowAccessApiImplTest {
             .newBuilder()
             .setTransaction(mockTransaction.builder().build())
             .build()
-        
         fun transactionResultResponse() = Access.TransactionResultResponse
             .newBuilder()
             .setStatus(TransactionOuterClass.TransactionStatus.SEALED)
@@ -154,12 +163,18 @@ class AsyncFlowAccessApiImplTest {
             .setId(ByteString.copyFromUtf8("01"))
             .build()
     }
-    
     // Helper functions for mocking objects and assertions
 
     private fun createMockEventsResponse(resultsCount: Int): Access.EventsResponse {
-        val results = List(resultsCount) { Access.EventsResponse.Result.newBuilder().build() }
-        return Access.EventsResponse.newBuilder().addAllResults(results).build()
+        val results = List(resultsCount) {
+            Access.EventsResponse.Result
+                .newBuilder()
+                .build()
+        }
+        return Access.EventsResponse
+            .newBuilder()
+            .addAllResults(results)
+            .build()
     }
 
     private fun createMockExecutionResult(blockId: FlowId): FlowExecutionResult {
@@ -169,21 +184,19 @@ class AsyncFlowAccessApiImplTest {
         return FlowExecutionResult(blockId = blockId, previousResultId = FlowId("02"), chunks = chunks, serviceEvents = serviceEvents)
     }
 
-    private fun createMockTransaction(referenceBlockId: String = "01"): FlowTransaction {
-        return FlowTransaction.of(
+    private fun createMockTransaction(referenceBlockId: String = "01"): FlowTransaction =
+        FlowTransaction.of(
             TransactionOuterClass.Transaction
                 .newBuilder()
                 .setReferenceBlockId(ByteString.copyFromUtf8(referenceBlockId))
                 .build()
         )
-    }
 
-    private fun createTransactionsResponse(transactions: List<FlowTransaction>): Access.TransactionsResponse {
-        return Access.TransactionsResponse
+    private fun createTransactionsResponse(transactions: List<FlowTransaction>): Access.TransactionsResponse =
+        Access.TransactionsResponse
             .newBuilder()
             .addAllTransactions(transactions.map { it.builder().build() })
             .build()
-    }
 
     private fun <T> assertSuccess(result: FlowAccessApi.AccessApiCallResponse<T>, expected: T) {
         assert(result is FlowAccessApi.AccessApiCallResponse.Success)
@@ -227,7 +240,6 @@ class AsyncFlowAccessApiImplTest {
         val flowAddress = FlowAddress("01")
         val keyIndex = 0
         val blockHeight = HEIGHT
-        
         val mockAccountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
         `when`(api.getAccountKeyAtBlockHeight(any())).thenReturn(setupFutureMock(MockResponseFactory.accountKeyResponse(mockAccountKey)))
 
@@ -365,7 +377,6 @@ class AsyncFlowAccessApiImplTest {
     fun `test getCollectionById`() {
         val collectionId = FlowId("01")
         val mockCollection = FlowCollection(collectionId, emptyList())
-        
         `when`(api.getCollectionByID(any())).thenReturn(setupFutureMock(MockResponseFactory.collectionResponse(mockCollection)))
 
         val result = asyncFlowAccessApi.getCollectionById(collectionId).get()
@@ -375,7 +386,6 @@ class AsyncFlowAccessApiImplTest {
     @Test
     fun `test sendTransaction`() {
         val mockTransaction = FlowTransaction(FlowScript("script"), emptyList(), FlowId.of("01".toByteArray()), 123L, FlowTransactionProposalKey(FlowAddress("02"), 1, 123L), FlowAddress("02"), emptyList())
-        
         `when`(api.sendTransaction(any())).thenReturn(setupFutureMock(MockResponseFactory.sendTransactionResponse()))
 
         val result = asyncFlowAccessApi.sendTransaction(mockTransaction).get()
@@ -385,7 +395,6 @@ class AsyncFlowAccessApiImplTest {
     @Test
     fun `test getTransactionById`() {
         val flowTransaction = FlowTransaction(FlowScript("script"), emptyList(), flowId, 123L, FlowTransactionProposalKey(FlowAddress("02"), 1, 123L), FlowAddress("02"), emptyList())
-        
         `when`(api.getTransaction(any())).thenReturn(setupFutureMock(MockResponseFactory.transactionResponse(flowTransaction)))
 
         val result = asyncFlowAccessApi.getTransactionById(flowId).get()
@@ -596,7 +605,8 @@ class AsyncFlowAccessApiImplTest {
     fun `test getTransactionsByBlockId with multiple results`() {
         val transactions = listOf(createMockTransaction(), createMockTransaction("02"))
 
-        val request = Access.GetTransactionsByBlockIDRequest.newBuilder()
+        val request = Access.GetTransactionsByBlockIDRequest
+            .newBuilder()
             .setBlockId(blockId.byteStringValue)
             .build()
 
@@ -632,8 +642,8 @@ class AsyncFlowAccessApiImplTest {
         executor.awaitTermination(2, TimeUnit.SECONDS)
     }
 
-    private fun createMockNodeVersionInfo(): Access.GetNodeVersionInfoResponse {
-        return Access.GetNodeVersionInfoResponse
+    private fun createMockNodeVersionInfo(): Access.GetNodeVersionInfoResponse =
+        Access.GetNodeVersionInfoResponse
             .newBuilder()
             .setInfo(
                 NodeVersionInfoOuterClass.NodeVersionInfo
@@ -652,5 +662,4 @@ class AsyncFlowAccessApiImplTest {
                             .build()
                     ).build()
             ).build()
-    }
 }

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -8,13 +8,13 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.onflow.flow.sdk.*
 import org.onflow.protobuf.access.Access
 import org.onflow.protobuf.access.AccessAPIGrpc
 import org.onflow.protobuf.entities.AccountOuterClass
-import org.onflow.protobuf.entities.ExecutionResultOuterClass
 import org.onflow.protobuf.entities.NodeVersionInfoOuterClass
 import org.onflow.protobuf.entities.TransactionOuterClass
 import java.math.BigDecimal
@@ -24,10 +24,10 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 class AsyncFlowAccessApiImplTest {
-    private val api = mock(AccessAPIGrpc.AccessAPIFutureStub::class.java)
-    private val asyncFlowAccessApi = AsyncFlowAccessApiImpl(api)
-
     companion object {
+        private val api = mock(AccessAPIGrpc.AccessAPIFutureStub::class.java)
+        private val asyncFlowAccessApi = AsyncFlowAccessApiImpl(api)
+
         val BLOCK_ID_BYTES = byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
         val PARENT_ID_BYTES = byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2)
 
@@ -60,221 +60,6 @@ class AsyncFlowAccessApiImplTest {
             parentView = 1L
         )
 
-        val mockTransactionResultResponse = Access.TransactionResultResponse
-            .newBuilder()
-            .setStatus(TransactionOuterClass.TransactionStatus.SEALED)
-            .setStatusCode(1)
-            .setErrorMessage("message")
-            .setBlockId(ByteString.copyFromUtf8("id"))
-            .setBlockHeight(1L)
-            .setTransactionId(ByteString.copyFromUtf8("id"))
-            .setCollectionId(ByteString.copyFromUtf8("id"))
-            .setComputationUsage(1L)
-            .build()
-    }
-
-    private fun <T> setupFutureMock(response: T): ListenableFuture<T> {
-        val future: ListenableFuture<T> = SettableFuture.create()
-        (future as SettableFuture<T>).set(response)
-        return future
-    }
-
-    @Test
-    fun `test ping`() {
-        val pingResponse = Access.PingResponse.newBuilder().build()
-        `when`(api.ping(any())).thenReturn(setupFutureMock(pingResponse))
-
-        val result = asyncFlowAccessApi.ping().get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-    }
-
-    @Test
-    fun `test getAccountKeyAtLatestBlock success`() {
-        val flowAddress = FlowAddress("01")
-        val keyIndex = 0
-        val mockAccountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
-        val response = Access.AccountKeyResponse
-            .newBuilder()
-            .setAccountKey(mockAccountKey.builder().build())
-            .build()
-
-        `when`(api.getAccountKeyAtLatestBlock(any())).thenReturn(setupFutureMock(response))
-
-        val result = asyncFlowAccessApi.getAccountKeyAtLatestBlock(flowAddress, keyIndex).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockAccountKey, result.data)
-    }
-
-    @Test
-    fun `test getAccountKeyAtLatestBlock failure`() {
-        val flowAddress = FlowAddress("01")
-        val keyIndex = 0
-        val exception = RuntimeException("Test exception")
-
-        `when`(api.getAccountKeyAtLatestBlock(any())).thenThrow(exception)
-
-        val result = asyncFlowAccessApi.getAccountKeyAtLatestBlock(flowAddress, keyIndex).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
-        result as FlowAccessApi.AccessApiCallResponse.Error
-        assertEquals("Failed to get account key at latest block", result.message)
-        assertEquals(exception, result.throwable)
-    }
-
-    @Test
-    fun `test getAccountKeyAtBlockHeight success`() {
-        val flowAddress = FlowAddress("01")
-        val keyIndex = 0
-        val blockHeight = HEIGHT
-        val mockAccountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
-        val response = Access.AccountKeyResponse
-            .newBuilder()
-            .setAccountKey(mockAccountKey.builder().build())
-            .build()
-
-        `when`(api.getAccountKeyAtBlockHeight(any())).thenReturn(setupFutureMock(response))
-
-        val result = asyncFlowAccessApi.getAccountKeyAtBlockHeight(flowAddress, keyIndex, blockHeight).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockAccountKey, result.data)
-    }
-
-    @Test
-    fun `test getAccountKeyAtBlockHeight failure`() {
-        val flowAddress = FlowAddress("01")
-        val keyIndex = 0
-        val blockHeight = HEIGHT
-        val exception = RuntimeException("Test exception")
-
-        `when`(api.getAccountKeyAtBlockHeight(any())).thenThrow(exception)
-
-        val result = asyncFlowAccessApi.getAccountKeyAtBlockHeight(flowAddress, keyIndex, blockHeight).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
-        result as FlowAccessApi.AccessApiCallResponse.Error
-        assertEquals("Failed to get account key at block height", result.message)
-        assertEquals(exception, result.throwable)
-    }
-
-    @Test
-    fun `test getAccountKeysAtLatestBlock success`() {
-        val flowAddress = FlowAddress("01")
-        val mockAccountKeys = listOf(
-            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
-            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
-        )
-        val response = Access.AccountKeysResponse
-            .newBuilder()
-            .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
-            .build()
-
-        `when`(api.getAccountKeysAtLatestBlock(any())).thenReturn(setupFutureMock(response))
-
-        val result = asyncFlowAccessApi.getAccountKeysAtLatestBlock(flowAddress).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockAccountKeys, result.data)
-    }
-
-    @Test
-    fun `test getAccountKeysAtLatestBlock failure`() {
-        val flowAddress = FlowAddress("01")
-        val exception = RuntimeException("Test exception")
-
-        `when`(api.getAccountKeysAtLatestBlock(any())).thenThrow(exception)
-
-        val result = asyncFlowAccessApi.getAccountKeysAtLatestBlock(flowAddress).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
-        result as FlowAccessApi.AccessApiCallResponse.Error
-        assertEquals("Failed to get account keys at latest block", result.message)
-        assertEquals(exception, result.throwable)
-    }
-
-    @Test
-    fun `test getAccountKeysAtBlockHeight success`() {
-        val flowAddress = FlowAddress("01")
-        val blockHeight = HEIGHT
-        val mockAccountKeys = listOf(
-            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
-            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
-        )
-        val response = Access.AccountKeysResponse
-            .newBuilder()
-            .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
-            .build()
-
-        `when`(api.getAccountKeysAtBlockHeight(any())).thenReturn(setupFutureMock(response))
-
-        val result = asyncFlowAccessApi.getAccountKeysAtBlockHeight(flowAddress, blockHeight).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockAccountKeys, result.data)
-    }
-
-    @Test
-    fun `test getAccountKeysAtBlockHeight failure`() {
-        val flowAddress = FlowAddress("01")
-        val blockHeight = HEIGHT
-        val exception = RuntimeException("Test exception")
-
-        `when`(api.getAccountKeysAtBlockHeight(any())).thenThrow(exception)
-
-        val result = asyncFlowAccessApi.getAccountKeysAtBlockHeight(flowAddress, blockHeight).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
-        result as FlowAccessApi.AccessApiCallResponse.Error
-        assertEquals("Failed to get account keys at block height", result.message)
-        assertEquals(exception, result.throwable)
-    }
-
-    @Test
-    fun `test getLatestBlockHeader`() {
-        val mockBlockHeader = mockBlockHeader
-        val blockHeaderResponse = Access.BlockHeaderResponse
-            .newBuilder()
-            .setBlock(mockBlockHeader.builder().build())
-            .build()
-        `when`(api.getLatestBlockHeader(any())).thenReturn(setupFutureMock(blockHeaderResponse))
-
-        val result = asyncFlowAccessApi.getLatestBlockHeader(true).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockBlockHeader, result.data)
-    }
-
-    @Test
-    fun `test getBlockHeaderById`() {
-        val blockId = FlowId.of(BLOCK_ID_BYTES)
-        val mockBlockHeader = mockBlockHeader
-        val blockHeaderResponse = Access.BlockHeaderResponse
-            .newBuilder()
-            .setBlock(mockBlockHeader.builder().build())
-            .build()
-        `when`(api.getBlockHeaderByID(any())).thenReturn(setupFutureMock(blockHeaderResponse))
-
-        val result = asyncFlowAccessApi.getBlockHeaderById(blockId).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockBlockHeader, result.data)
-    }
-
-    @Test
-    fun `test getBlockHeaderByHeight`() {
-        val height = HEIGHT
-        val mockBlockHeader = mockBlockHeader
-        val blockHeaderResponse = Access.BlockHeaderResponse
-            .newBuilder()
-            .setBlock(mockBlockHeader.builder().build())
-            .build()
-        `when`(api.getBlockHeaderByHeight(any())).thenReturn(setupFutureMock(blockHeaderResponse))
-
-        val result = asyncFlowAccessApi.getBlockHeaderByHeight(height).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockBlockHeader, result.data)
-    }
-
-    @Test
-    fun `test getLatestBlock`() {
         val mockBlock = FlowBlock(
             id = FlowId.of(BLOCK_ID_BYTES),
             parentId = FlowId.of(PARENT_ID_BYTES),
@@ -288,230 +73,354 @@ class AsyncFlowAccessApiImplTest {
             blockHeader = mockBlockHeader,
             protocolStateId = FlowId.of(ByteArray(32))
         )
-        val blockResponse = Access.BlockResponse
+
+        val flowId = FlowId.of("id".toByteArray())
+        val blockId = FlowId("01")
+
+        val mockAccountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        val mockAccountKeys = listOf(
+            mockAccountKey,
+            mockAccountKey
+        )
+        val testException = RuntimeException("Test exception")
+    }
+
+    private fun <T> setupFutureMock(response: T): ListenableFuture<T> {
+        val future: ListenableFuture<T> = SettableFuture.create()
+        (future as SettableFuture<T>).set(response)
+        return future
+    }
+
+    private object MockResponseFactory {
+        fun accountKeyResponse(accountKey: FlowAccountKey) = Access.AccountKeyResponse
+            .newBuilder().setAccountKey(accountKey.builder().build()).build()
+
+        fun accountKeysResponse(accountKeys: List<FlowAccountKey>) = Access.AccountKeysResponse
+            .newBuilder().addAllAccountKeys(accountKeys.map { it.builder().build() }).build()
+
+        fun accountBalanceResponse(balance: Long) = Access.AccountBalanceResponse
+            .newBuilder().setBalance(balance).build()
+
+        fun blockHeaderResponse(mockBlockHeader: FlowBlockHeader) = Access.BlockHeaderResponse
+            .newBuilder().setBlock(mockBlockHeader.builder().build()).build()
+
+        fun blockResponse(mockBlock: FlowBlock) = Access.BlockResponse
+            .newBuilder().setBlock(mockBlock.builder().build()).build()
+
+        fun collectionResponse(mockCollection: FlowCollection) = Access.CollectionResponse
             .newBuilder()
-            .setBlock(mockBlock.builder().build())
+            .setCollection(mockCollection.builder().build())
             .build()
-        `when`(api.getLatestBlock(any())).thenReturn(setupFutureMock(blockResponse))
+
+        fun executionResultResponse(mockExecutionResult: FlowExecutionResult) = Access.ExecutionResultByIDResponse
+            .newBuilder()
+            .setExecutionResult(mockExecutionResult.builder().build())
+            .build()
+
+        fun transactionResponse(mockTransaction: FlowTransaction) = Access.TransactionResponse
+            .newBuilder()
+            .setTransaction(mockTransaction.builder().build())
+            .build()
+        
+        fun transactionResultResponse() = Access.TransactionResultResponse
+            .newBuilder()
+            .setStatus(TransactionOuterClass.TransactionStatus.SEALED)
+            .setStatusCode(1)
+            .setErrorMessage("message")
+            .setBlockId(ByteString.copyFromUtf8("id"))
+            .setBlockHeight(HEIGHT)
+            .setTransactionId(ByteString.copyFromUtf8("id"))
+            .setCollectionId(ByteString.copyFromUtf8("id"))
+            .setComputationUsage(1L)
+            .build()
+
+        fun networkParametersResponse() = Access.GetNetworkParametersResponse
+            .newBuilder()
+            .setChainId("test_chain_id")
+            .build()
+
+        fun protocolStateSnapshotResponse() = Access.ProtocolStateSnapshotResponse
+            .newBuilder()
+            .setSerializedSnapshot(ByteString.copyFromUtf8("test_serialized_snapshot"))
+            .build()
+
+        fun scriptResponse() = Access.ExecuteScriptResponse
+            .newBuilder()
+            .setValue(ByteString.copyFromUtf8("response_value"))
+            .build()
+
+        fun sendTransactionResponse() = Access.SendTransactionResponse
+            .newBuilder()
+            .setId(ByteString.copyFromUtf8("01"))
+            .build()
+    }
+    
+    // Helper functions for mocking objects and assertions
+
+    private fun createMockEventsResponse(resultsCount: Int): Access.EventsResponse {
+        val results = List(resultsCount) { Access.EventsResponse.Result.newBuilder().build() }
+        return Access.EventsResponse.newBuilder().addAllResults(results).build()
+    }
+
+    private fun createMockExecutionResult(blockId: FlowId): FlowExecutionResult {
+        val chunks = listOf(FlowChunk(collectionIndex = 1, startState = ByteArray(0), eventCollection = ByteArray(0), blockId = FlowId("01"), totalComputationUsed = 1000L, numberOfTransactions = 10, index = 1L, endState = ByteArray(0), executionDataId = FlowId("02"), stateDeltaCommitment = ByteArray(0)))
+        val serviceEvents = listOf(FlowServiceEvent(type = "ServiceEventType", payload = ByteArray(0)))
+
+        return FlowExecutionResult(blockId = blockId, previousResultId = FlowId("02"), chunks = chunks, serviceEvents = serviceEvents)
+    }
+
+    private fun createMockTransaction(referenceBlockId: String = "01"): FlowTransaction {
+        return FlowTransaction.of(
+            TransactionOuterClass.Transaction
+                .newBuilder()
+                .setReferenceBlockId(ByteString.copyFromUtf8(referenceBlockId))
+                .build()
+        )
+    }
+
+    private fun createTransactionsResponse(transactions: List<FlowTransaction>): Access.TransactionsResponse {
+        return Access.TransactionsResponse
+            .newBuilder()
+            .addAllTransactions(transactions.map { it.builder().build() })
+            .build()
+    }
+
+    private fun <T> assertSuccess(result: FlowAccessApi.AccessApiCallResponse<T>, expected: T) {
+        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
+        assertEquals(expected, (result as FlowAccessApi.AccessApiCallResponse.Success).data)
+    }
+
+    private fun assertFailure(result: FlowAccessApi.AccessApiCallResponse<*>, expectedMessage: String, expectedThrowable: Throwable) {
+        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
+        result as FlowAccessApi.AccessApiCallResponse.Error
+        assertEquals(expectedMessage, result.message)
+        assertEquals(expectedThrowable, result.throwable)
+    }
+
+    @Test
+    fun `test ping`() {
+        val pingResponse = Access.PingResponse.newBuilder().build()
+        `when`(api.ping(any())).thenReturn(setupFutureMock(pingResponse))
+
+        val result = asyncFlowAccessApi.ping().get()
+        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
+    }
+
+    @Test
+    fun `test getAccountKeyAtLatestBlock success`() {
+        `when`(api.getAccountKeyAtLatestBlock(any())).thenReturn(setupFutureMock(MockResponseFactory.accountKeyResponse(mockAccountKey)))
+
+        val result = asyncFlowAccessApi.getAccountKeyAtLatestBlock(FlowAddress("01"), 0).get()
+        assertSuccess(result, mockAccountKey)
+    }
+
+    @Test
+    fun `test getAccountKeyAtLatestBlock failure`() {
+        `when`(api.getAccountKeyAtLatestBlock(any())).thenThrow(testException)
+
+        val result = asyncFlowAccessApi.getAccountKeyAtLatestBlock(FlowAddress("01"), 0).get()
+        assertFailure(result, "Failed to get account key at latest block", testException)
+    }
+
+    @Test
+    fun `test getAccountKeyAtBlockHeight success`() {
+        val flowAddress = FlowAddress("01")
+        val keyIndex = 0
+        val blockHeight = HEIGHT
+        
+        val mockAccountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        `when`(api.getAccountKeyAtBlockHeight(any())).thenReturn(setupFutureMock(MockResponseFactory.accountKeyResponse(mockAccountKey)))
+
+        val result = asyncFlowAccessApi.getAccountKeyAtBlockHeight(flowAddress, keyIndex, blockHeight).get()
+        assertSuccess(result, mockAccountKey)
+    }
+
+    @Test
+    fun `test getAccountKeyAtBlockHeight failure`() {
+        val flowAddress = FlowAddress("01")
+        val keyIndex = 0
+        val blockHeight = HEIGHT
+
+        `when`(api.getAccountKeyAtBlockHeight(any())).thenThrow(testException)
+
+        val result = asyncFlowAccessApi.getAccountKeyAtBlockHeight(flowAddress, keyIndex, blockHeight).get()
+        assertFailure(result, "Failed to get account key at block height", testException)
+    }
+
+    @Test
+    fun `test getAccountKeysAtLatestBlock success`() {
+        `when`(api.getAccountKeysAtLatestBlock(any())).thenReturn(setupFutureMock(MockResponseFactory.accountKeysResponse(mockAccountKeys)))
+
+        val result = asyncFlowAccessApi.getAccountKeysAtLatestBlock(FlowAddress("01")).get()
+        assertSuccess(result, mockAccountKeys)
+    }
+
+    @Test
+    fun `test getAccountKeysAtLatestBlock failure`() {
+        `when`(api.getAccountKeysAtLatestBlock(any())).thenThrow(testException)
+
+        val result = asyncFlowAccessApi.getAccountKeysAtLatestBlock(FlowAddress("01")).get()
+        assertFailure(result, "Failed to get account keys at latest block", testException)
+    }
+
+    @Test
+    fun `test getAccountKeysAtBlockHeight success`() {
+        val flowAddress = FlowAddress("01")
+        val blockHeight = HEIGHT
+
+        `when`(api.getAccountKeysAtBlockHeight(any())).thenReturn(setupFutureMock(MockResponseFactory.accountKeysResponse(mockAccountKeys)))
+
+        val result = asyncFlowAccessApi.getAccountKeysAtBlockHeight(flowAddress, blockHeight).get()
+        assertSuccess(result, mockAccountKeys)
+    }
+
+    @Test
+    fun `test getAccountKeysAtBlockHeight failure`() {
+        val flowAddress = FlowAddress("01")
+        val blockHeight = HEIGHT
+
+        `when`(api.getAccountKeysAtBlockHeight(any())).thenThrow(testException)
+
+        val result = asyncFlowAccessApi.getAccountKeysAtBlockHeight(flowAddress, blockHeight).get()
+        assertFailure(result, "Failed to get account keys at block height", testException)
+    }
+
+    @Test
+    fun `test getLatestBlockHeader`() {
+        `when`(api.getLatestBlockHeader(any())).thenReturn(setupFutureMock(MockResponseFactory.blockHeaderResponse(mockBlockHeader)))
+
+        val result = asyncFlowAccessApi.getLatestBlockHeader(true).get()
+        assertSuccess(result, mockBlockHeader)
+    }
+
+    @Test
+    fun `test getBlockHeaderById`() {
+        `when`(api.getBlockHeaderByID(any())).thenReturn(setupFutureMock(MockResponseFactory.blockHeaderResponse(mockBlockHeader)))
+
+        val result = asyncFlowAccessApi.getBlockHeaderById(blockId).get()
+        assertSuccess(result, mockBlockHeader)
+    }
+
+    @Test
+    fun `test getBlockHeaderByHeight`() {
+        `when`(api.getBlockHeaderByHeight(any())).thenReturn(setupFutureMock(MockResponseFactory.blockHeaderResponse(mockBlockHeader)))
+
+        val result = asyncFlowAccessApi.getBlockHeaderByHeight(HEIGHT).get()
+        assertSuccess(result, mockBlockHeader)
+    }
+
+    @Test
+    fun `test getLatestBlock`() {
+        `when`(api.getLatestBlock(any())).thenReturn(setupFutureMock(MockResponseFactory.blockResponse(mockBlock)))
 
         val result = asyncFlowAccessApi.getLatestBlock(true).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockBlock, result.data)
+        assertSuccess(result, mockBlock)
     }
 
     @Test
     fun `test getBlockById`() {
-        val blockId = FlowId.of(BLOCK_ID_BYTES)
-        val mockBlock = FlowBlock(
-            id = blockId,
-            parentId = FlowId.of(PARENT_ID_BYTES),
-            height = 123L,
-            timestamp = LocalDateTime.now(),
-            collectionGuarantees = emptyList(),
-            blockSeals = emptyList(),
-            signatures = emptyList(),
-            executionReceiptMetaList = emptyList(),
-            executionResultList = emptyList(),
-            blockHeader = mockBlockHeader,
-            protocolStateId = FlowId.of(ByteArray(32))
-        )
-        val blockResponse = Access.BlockResponse
-            .newBuilder()
-            .setBlock(mockBlock.builder().build())
-            .build()
-        `when`(api.getBlockByID(any())).thenReturn(setupFutureMock(blockResponse))
+        `when`(api.getBlockByID(any())).thenReturn(setupFutureMock(MockResponseFactory.blockResponse(mockBlock)))
 
         val result = asyncFlowAccessApi.getBlockById(blockId).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockBlock, result.data)
+        assertSuccess(result, mockBlock)
     }
 
     @Test
     fun `test getBlockByHeight`() {
-        val height = HEIGHT
-        val mockBlock = FlowBlock(
-            FlowId("01"),
-            FlowId("01"),
-            height,
-            LocalDateTime.now(),
-            emptyList(),
-            emptyList(),
-            emptyList(),
-            emptyList(),
-            emptyList(),
-            mockBlockHeader,
-            FlowId.of(ByteArray(32))
-        )
-        val blockResponse = Access.BlockResponse
-            .newBuilder()
-            .setBlock(mockBlock.builder().build())
-            .build()
-        `when`(api.getBlockByHeight(any())).thenReturn(setupFutureMock(blockResponse))
+        `when`(api.getBlockByHeight(any())).thenReturn(setupFutureMock(MockResponseFactory.blockResponse(mockBlock)))
 
-        val result = asyncFlowAccessApi.getBlockByHeight(height).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockBlock, result.data)
+        val result = asyncFlowAccessApi.getBlockByHeight(HEIGHT).get()
+        assertSuccess(result, mockBlock)
     }
 
     @Test
     fun `test getAccountBalanceAtLatestBlock success`() {
-        val flowAddress = FlowAddress("01")
         val expectedBalance = 1000L
-        val balanceResponse = Access.AccountBalanceResponse
-            .newBuilder()
-            .setBalance(expectedBalance)
-            .build()
+        `when`(api.getAccountBalanceAtLatestBlock(any())).thenReturn(setupFutureMock(MockResponseFactory.accountBalanceResponse(expectedBalance)))
 
-        `when`(api.getAccountBalanceAtLatestBlock(any())).thenReturn(setupFutureMock(balanceResponse))
-
-        val result = asyncFlowAccessApi.getAccountBalanceAtLatestBlock(flowAddress).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(expectedBalance, result.data)
+        val result = asyncFlowAccessApi.getAccountBalanceAtLatestBlock(FlowAddress("01")).get()
+        assertSuccess(result, expectedBalance)
     }
 
     @Test
     fun `test getAccountBalanceAtLatestBlock failure`() {
-        val flowAddress = FlowAddress("01")
-        val exception = RuntimeException("Test exception")
+        `when`(api.getAccountBalanceAtLatestBlock(any())).thenThrow(testException)
 
-        `when`(api.getAccountBalanceAtLatestBlock(any())).thenThrow(exception)
-
-        val result = asyncFlowAccessApi.getAccountBalanceAtLatestBlock(flowAddress).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
-        result as FlowAccessApi.AccessApiCallResponse.Error
-        assertEquals("Failed to get account balance at latest block", result.message)
-        assertEquals(exception, result.throwable)
+        val result = asyncFlowAccessApi.getAccountBalanceAtLatestBlock(FlowAddress("01")).get()
+        assertFailure(result, "Failed to get account balance at latest block", testException)
     }
 
     @Test
     fun `test getAccountBalanceAtBlockHeight success`() {
         val flowAddress = FlowAddress("01")
-        val blockHeight = 123L
         val expectedBalance = 1000L
-        val balanceResponse = Access.AccountBalanceResponse
-            .newBuilder()
-            .setBalance(expectedBalance)
-            .build()
 
-        `when`(api.getAccountBalanceAtBlockHeight(any())).thenReturn(setupFutureMock(balanceResponse))
+        `when`(api.getAccountBalanceAtBlockHeight(any())).thenReturn(setupFutureMock(MockResponseFactory.accountBalanceResponse(expectedBalance)))
 
-        val result = asyncFlowAccessApi.getAccountBalanceAtBlockHeight(flowAddress, blockHeight).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(expectedBalance, result.data)
-    }
-
-    @Test
-    fun `test getAccountBalanceAtBlockHeight failure`() {
-        val flowAddress = FlowAddress("01")
-        val blockHeight = 123L
-        val exception = RuntimeException("Test exception")
-
-        `when`(api.getAccountBalanceAtBlockHeight(any())).thenThrow(exception)
-
-        val result = asyncFlowAccessApi.getAccountBalanceAtBlockHeight(flowAddress, blockHeight).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
-        result as FlowAccessApi.AccessApiCallResponse.Error
-        assertEquals("Failed to get account balance at block height", result.message)
-        assertEquals(exception, result.throwable)
+        val result = asyncFlowAccessApi.getAccountBalanceAtBlockHeight(flowAddress, HEIGHT).get()
+        assertSuccess(result, expectedBalance)
     }
 
     @Test
     fun `test getCollectionById`() {
         val collectionId = FlowId("01")
         val mockCollection = FlowCollection(collectionId, emptyList())
-        val collectionResponse = Access.CollectionResponse
-            .newBuilder()
-            .setCollection(mockCollection.builder().build())
-            .build()
-        `when`(api.getCollectionByID(any())).thenReturn(setupFutureMock(collectionResponse))
+        
+        `when`(api.getCollectionByID(any())).thenReturn(setupFutureMock(MockResponseFactory.collectionResponse(mockCollection)))
 
         val result = asyncFlowAccessApi.getCollectionById(collectionId).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockCollection, result.data)
+        assertSuccess(result, mockCollection)
     }
 
     @Test
     fun `test sendTransaction`() {
         val mockTransaction = FlowTransaction(FlowScript("script"), emptyList(), FlowId.of("01".toByteArray()), 123L, FlowTransactionProposalKey(FlowAddress("02"), 1, 123L), FlowAddress("02"), emptyList())
-
-        val transactionResponse = Access.SendTransactionResponse
-            .newBuilder()
-            .setId(ByteString.copyFromUtf8("01"))
-            .build()
-        `when`(api.sendTransaction(any())).thenReturn(setupFutureMock(transactionResponse))
+        
+        `when`(api.sendTransaction(any())).thenReturn(setupFutureMock(MockResponseFactory.sendTransactionResponse()))
 
         val result = asyncFlowAccessApi.sendTransaction(mockTransaction).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(FlowId.of("01".toByteArray()), result.data)
+        assertSuccess(result, FlowId.of("01".toByteArray()))
     }
 
     @Test
     fun `test getTransactionById`() {
-        val flowId = FlowId("01")
         val flowTransaction = FlowTransaction(FlowScript("script"), emptyList(), flowId, 123L, FlowTransactionProposalKey(FlowAddress("02"), 1, 123L), FlowAddress("02"), emptyList())
-        val transactionResponse = Access.TransactionResponse
-            .newBuilder()
-            .setTransaction(flowTransaction.builder().build())
-            .build()
-        `when`(api.getTransaction(any())).thenReturn(setupFutureMock(transactionResponse))
+        
+        `when`(api.getTransaction(any())).thenReturn(setupFutureMock(MockResponseFactory.transactionResponse(flowTransaction)))
 
         val result = asyncFlowAccessApi.getTransactionById(flowId).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(flowTransaction, result.data)
+        assertSuccess(result, flowTransaction)
     }
 
     @Test
     fun `test getTransactionResultById`() {
-        val flowId = FlowId.of("id".toByteArray())
-        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId, 1L, flowId, flowId, 1L)
+        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId, HEIGHT, flowId, flowId, 1L)
 
-        val transactionResultResponse = mockTransactionResultResponse
-
-        `when`(api.getTransactionResult(any())).thenReturn(setupFutureMock(transactionResultResponse))
+        `when`(api.getTransactionResult(any())).thenReturn(setupFutureMock(MockResponseFactory.transactionResultResponse()))
 
         val result = asyncFlowAccessApi.getTransactionResultById(flowId).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(flowTransactionResult, result.data)
+        assertSuccess(result, flowTransactionResult)
     }
 
     @Test
     fun `test getTransactionResultByIndex success`() {
         val index = 0
-        val flowId = FlowId.of("id".toByteArray())
-        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId, 1L, flowId, flowId, 1L)
+        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId, HEIGHT, flowId, flowId, 1L)
 
-        val transactionResultResponse = mockTransactionResultResponse
-
-        `when`(api.getTransactionResultByIndex(any())).thenReturn(setupFutureMock(transactionResultResponse))
+        `when`(api.getTransactionResultByIndex(any())).thenReturn(setupFutureMock(MockResponseFactory.transactionResultResponse()))
 
         val result = asyncFlowAccessApi.getTransactionResultByIndex(flowId, index).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(flowTransactionResult, result.data)
+        assertSuccess(result, flowTransactionResult)
     }
 
     @Test
     fun `test getTransactionResultByIndex failure`() {
         val index = 0
-        val flowId = FlowId.of("id".toByteArray())
-        val exception = RuntimeException("Test exception")
 
-        `when`(api.getTransactionResultByIndex(any())).thenThrow(exception)
+        `when`(api.getTransactionResultByIndex(any())).thenThrow(testException)
 
         val result = asyncFlowAccessApi.getTransactionResultByIndex(flowId, index).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Error)
-        result as FlowAccessApi.AccessApiCallResponse.Error
-        assertEquals("Failed to get transaction result by index", result.message)
-        assertEquals(exception, result.throwable)
+        assertFailure(result, "Failed to get transaction result by index", testException)
     }
 
     @Test
@@ -576,11 +485,8 @@ class AsyncFlowAccessApiImplTest {
     fun `test executeScriptAtLatestBlock`() {
         val script = FlowScript("script".toByteArray())
         val arguments = listOf(ByteString.copyFromUtf8("argument1"), ByteString.copyFromUtf8("argument2"))
-        val scriptResponse = Access.ExecuteScriptResponse
-            .newBuilder()
-            .setValue(ByteString.copyFromUtf8("response_value"))
-            .build()
-        `when`(api.executeScriptAtLatestBlock(any())).thenReturn(setupFutureMock(scriptResponse))
+
+        `when`(api.executeScriptAtLatestBlock(any())).thenReturn(setupFutureMock(MockResponseFactory.scriptResponse()))
 
         val result = asyncFlowAccessApi.executeScriptAtLatestBlock(script, arguments).get()
         assert(result is FlowAccessApi.AccessApiCallResponse.Success)
@@ -591,13 +497,9 @@ class AsyncFlowAccessApiImplTest {
     @Test
     fun `test executeScriptAtBlockId`() {
         val script = FlowScript("some_script")
-        val blockId = FlowId("01")
         val arguments = listOf(ByteString.copyFromUtf8("argument1"), ByteString.copyFromUtf8("argument2"))
-        val scriptResponse = Access.ExecuteScriptResponse
-            .newBuilder()
-            .setValue(ByteString.copyFromUtf8("response_value"))
-            .build()
-        `when`(api.executeScriptAtBlockID(any())).thenReturn(setupFutureMock(scriptResponse))
+
+        `when`(api.executeScriptAtBlockID(any())).thenReturn(setupFutureMock(MockResponseFactory.scriptResponse()))
 
         val result = asyncFlowAccessApi.executeScriptAtBlockId(script, blockId, arguments).get()
         assert(result is FlowAccessApi.AccessApiCallResponse.Success)
@@ -608,13 +510,10 @@ class AsyncFlowAccessApiImplTest {
     @Test
     fun `test executeScriptAtBlockHeight`() {
         val script = FlowScript("some_script")
-        val height = 123L
+        val height = HEIGHT
         val arguments = listOf(ByteString.copyFromUtf8("argument1"), ByteString.copyFromUtf8("argument2"))
-        val scriptResponse = Access.ExecuteScriptResponse
-            .newBuilder()
-            .setValue(ByteString.copyFromUtf8("response_value"))
-            .build()
-        `when`(api.executeScriptAtBlockHeight(any())).thenReturn(setupFutureMock(scriptResponse))
+
+        `when`(api.executeScriptAtBlockHeight(any())).thenReturn(setupFutureMock(MockResponseFactory.scriptResponse()))
 
         val result = asyncFlowAccessApi.executeScriptAtBlockHeight(script, height, arguments).get()
         assert(result is FlowAccessApi.AccessApiCallResponse.Success)
@@ -626,18 +525,7 @@ class AsyncFlowAccessApiImplTest {
     fun `test getEventsForHeightRange`() {
         val type = "event_type"
         val range = 1L..10L
-        val eventResult1 = Access.EventsResponse.Result
-            .newBuilder()
-            .build()
-        val eventResult2 = Access.EventsResponse.Result
-            .newBuilder()
-            .build()
-        val response = Access.EventsResponse
-            .newBuilder()
-            .addResults(eventResult1)
-            .addResults(eventResult2)
-            .build()
-        `when`(api.getEventsForHeightRange(any())).thenReturn(setupFutureMock(response))
+        `when`(api.getEventsForHeightRange(any())).thenReturn(setupFutureMock(createMockEventsResponse(2)))
 
         val result = asyncFlowAccessApi.getEventsForHeightRange(type, range).get()
         assert(result is FlowAccessApi.AccessApiCallResponse.Success)
@@ -649,18 +537,7 @@ class AsyncFlowAccessApiImplTest {
     fun `test getEventsForBlockIds`() {
         val type = "event_type"
         val blockIds = setOf(FlowId("01"), FlowId("02"))
-        val eventResult1 = Access.EventsResponse.Result
-            .newBuilder()
-            .build()
-        val eventResult2 = Access.EventsResponse.Result
-            .newBuilder()
-            .build()
-        val response = Access.EventsResponse
-            .newBuilder()
-            .addResults(eventResult1)
-            .addResults(eventResult2)
-            .build()
-        `when`(api.getEventsForBlockIDs(any())).thenReturn(setupFutureMock(response))
+        `when`(api.getEventsForBlockIDs(any())).thenReturn(setupFutureMock(createMockEventsResponse(2)))
 
         val result = asyncFlowAccessApi.getEventsForBlockIds(type, blockIds).get()
         assert(result is FlowAccessApi.AccessApiCallResponse.Success)
@@ -671,36 +548,92 @@ class AsyncFlowAccessApiImplTest {
     @Test
     fun `test getNetworkParameters`() {
         val mockFlowChainId = FlowChainId.of("test_chain_id")
-        val networkParametersResponse = Access.GetNetworkParametersResponse
-            .newBuilder()
-            .setChainId("test_chain_id")
-            .build()
-        `when`(api.getNetworkParameters(any())).thenReturn(setupFutureMock(networkParametersResponse))
+        `when`(api.getNetworkParameters(any())).thenReturn(setupFutureMock(MockResponseFactory.networkParametersResponse()))
 
         val result = asyncFlowAccessApi.getNetworkParameters().get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockFlowChainId, result.data)
+        assertSuccess(result, mockFlowChainId)
     }
 
     @Test
     fun `test getLatestProtocolStateSnapshot`() {
         val mockFlowSnapshot = FlowSnapshot("test_serialized_snapshot".toByteArray())
-        val protocolStateSnapshotResponse = Access.ProtocolStateSnapshotResponse
-            .newBuilder()
-            .setSerializedSnapshot(ByteString.copyFromUtf8("test_serialized_snapshot"))
-            .build()
-        `when`(api.getLatestProtocolStateSnapshot(any())).thenReturn(setupFutureMock(protocolStateSnapshotResponse))
+        `when`(api.getLatestProtocolStateSnapshot(any())).thenReturn(setupFutureMock(MockResponseFactory.protocolStateSnapshotResponse()))
 
         val result = asyncFlowAccessApi.getLatestProtocolStateSnapshot().get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(mockFlowSnapshot, result.data)
+        assertSuccess(result, mockFlowSnapshot)
     }
 
     @Test
     fun `test getNodeVersionInfo`() {
-        val mockNodeVersionInfo = Access.GetNodeVersionInfoResponse
+        val mockNodeVersionInfo = createMockNodeVersionInfo()
+        `when`(api.getNodeVersionInfo(any())).thenReturn(setupFutureMock(mockNodeVersionInfo))
+
+        val result = asyncFlowAccessApi.getNodeVersionInfo().get()
+        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
+
+        result as FlowAccessApi.AccessApiCallResponse.Success
+        val nodeVersionInfo = result.data
+        assertEquals("v0.0.1", nodeVersionInfo.semver)
+        assertEquals("123456", nodeVersionInfo.commit)
+        assertArrayEquals("sporkId".toByteArray(), nodeVersionInfo.sporkId)
+        assertEquals(5, nodeVersionInfo.protocolVersion)
+        assertEquals(1000L, nodeVersionInfo.sporkRootBlockHeight)
+        assertEquals(1001L, nodeVersionInfo.nodeRootBlockHeight)
+        assertEquals(100L, nodeVersionInfo.compatibleRange?.startHeight)
+        assertEquals(200L, nodeVersionInfo.compatibleRange?.endHeight)
+    }
+
+    @Test
+    fun `test getTransactionsByBlockId single result`() {
+        val transactions = listOf(createMockTransaction())
+        `when`(api.getTransactionsByBlockID(any())).thenReturn(setupFutureMock(createTransactionsResponse(transactions)))
+
+        val result = asyncFlowAccessApi.getTransactionsByBlockId(blockId).get()
+        assertSuccess(result, transactions)
+    }
+
+    @Test
+    fun `test getTransactionsByBlockId with multiple results`() {
+        val transactions = listOf(createMockTransaction(), createMockTransaction("02"))
+
+        val request = Access.GetTransactionsByBlockIDRequest.newBuilder()
+            .setBlockId(blockId.byteStringValue)
+            .build()
+
+        `when`(api.getTransactionsByBlockID(eq(request))).thenReturn(setupFutureMock(createTransactionsResponse(transactions)))
+
+        val result = asyncFlowAccessApi.getTransactionsByBlockId(blockId).get()
+        assertSuccess(result, transactions)
+    }
+
+    @Test
+    fun `test getExecutionResultByBlockId`() {
+        val executionResult = createMockExecutionResult(blockId)
+
+        `when`(api.getExecutionResultByID(any())).thenReturn(setupFutureMock(MockResponseFactory.executionResultResponse(executionResult)))
+
+        val result = asyncFlowAccessApi.getExecutionResultByBlockId(blockId).get()
+        assertSuccess(result, executionResult)
+    }
+
+    @Test
+    fun `test getTransactionsByBlockId timeout exception`() {
+        val future: ListenableFuture<Access.TransactionsResponse> = SettableFuture.create()
+        `when`(api.getTransactionsByBlockID(any())).thenReturn(future)
+
+        val executor = Executors.newSingleThreadExecutor()
+        executor.submit {
+            assertThrows<TimeoutException> {
+                asyncFlowAccessApi.getTransactionsByBlockId(blockId).get(1, TimeUnit.SECONDS)
+            }
+        }
+
+        executor.shutdown()
+        executor.awaitTermination(2, TimeUnit.SECONDS)
+    }
+
+    private fun createMockNodeVersionInfo(): Access.GetNodeVersionInfoResponse {
+        return Access.GetNodeVersionInfoResponse
             .newBuilder()
             .setInfo(
                 NodeVersionInfoOuterClass.NodeVersionInfo
@@ -719,184 +652,5 @@ class AsyncFlowAccessApiImplTest {
                             .build()
                     ).build()
             ).build()
-
-        `when`(api.getNodeVersionInfo(any())).thenReturn(setupFutureMock(mockNodeVersionInfo))
-
-        val result = asyncFlowAccessApi.getNodeVersionInfo().get()
-
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        val nodeVersionInfo = result.data
-
-        assertEquals("v0.0.1", nodeVersionInfo.semver)
-        assertEquals("123456", nodeVersionInfo.commit)
-        assertArrayEquals("sporkId".toByteArray(), nodeVersionInfo.sporkId)
-        assertEquals(5, nodeVersionInfo.protocolVersion)
-        assertEquals(1000L, nodeVersionInfo.sporkRootBlockHeight)
-        assertEquals(1001L, nodeVersionInfo.nodeRootBlockHeight)
-        assertEquals(100L, nodeVersionInfo.compatibleRange?.startHeight)
-        assertEquals(200L, nodeVersionInfo.compatibleRange?.endHeight)
-    }
-
-    @Test
-    fun `test getTransactionsByBlockId`() {
-        val blockId = FlowId("01")
-        val transactions = listOf(FlowTransaction.of(TransactionOuterClass.Transaction.getDefaultInstance()))
-        val response = Access.TransactionsResponse
-            .newBuilder()
-            .addAllTransactions(transactions.map { it.builder().build() })
-            .build()
-        `when`(api.getTransactionsByBlockID(any())).thenReturn(setupFutureMock(response))
-
-        val result = asyncFlowAccessApi.getTransactionsByBlockId(blockId).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(transactions, result.data)
-    }
-
-    @Test
-    fun `test getTransactionsByBlockId with multiple results`() {
-        val blockId = FlowId("01")
-        val transaction1 = FlowTransaction.of(TransactionOuterClass.Transaction.getDefaultInstance())
-        val transaction2 = FlowTransaction.of(
-            TransactionOuterClass.Transaction
-                .newBuilder()
-                .setReferenceBlockId(ByteString.copyFromUtf8("02"))
-                .build()
-        )
-        val transactions = listOf(transaction1, transaction2)
-        val response = Access.TransactionsResponse
-            .newBuilder()
-            .addAllTransactions(transactions.map { it.builder().build() })
-            .build()
-        `when`(api.getTransactionsByBlockID(any())).thenReturn(setupFutureMock(response))
-
-        val result = asyncFlowAccessApi.getTransactionsByBlockId(blockId).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(2, result.data.size)
-        assertEquals(transaction1, result.data[0])
-        assertEquals(transaction2, result.data[1])
-    }
-
-    @Test
-    fun `test getTransactionResultsByBlockId`() {
-        val blockId = FlowId("01")
-        val transactionResults = listOf(FlowTransactionResult.of(Access.TransactionResultResponse.getDefaultInstance()))
-        val response = Access.TransactionResultsResponse
-            .newBuilder()
-            .addAllTransactionResults(transactionResults.map { it.builder().build() })
-            .build()
-        `when`(api.getTransactionResultsByBlockID(any())).thenReturn(setupFutureMock(response))
-
-        val result = asyncFlowAccessApi.getTransactionResultsByBlockId(blockId).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(transactionResults, result.data)
-    }
-
-    @Test
-    fun `test getTransactionResultsByBlockId with multiple results`() {
-        val blockId = FlowId("01")
-        val transactionResult1 = FlowTransactionResult.of(
-            Access.TransactionResultResponse
-                .newBuilder()
-                .setStatus(TransactionOuterClass.TransactionStatus.SEALED)
-                .setStatusCode(1)
-                .setErrorMessage("message1")
-                .build()
-        )
-        val transactionResult2 = FlowTransactionResult.of(
-            Access.TransactionResultResponse
-                .newBuilder()
-                .setStatus(TransactionOuterClass.TransactionStatus.SEALED)
-                .setStatusCode(2)
-                .setErrorMessage("message2")
-                .build()
-        )
-        val transactionResults = listOf(transactionResult1, transactionResult2)
-        val response = Access.TransactionResultsResponse
-            .newBuilder()
-            .addAllTransactionResults(transactionResults.map { it.builder().build() })
-            .build()
-        `when`(api.getTransactionResultsByBlockID(any())).thenReturn(setupFutureMock(response))
-
-        val result = asyncFlowAccessApi.getTransactionResultsByBlockId(blockId).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(2, result.data.size)
-        assertEquals(transactionResult1, result.data[0])
-        assertEquals(transactionResult2, result.data[1])
-    }
-
-    @Test
-    fun `test getExecutionResultByBlockId`() {
-        val blockId = FlowId("01")
-
-        val chunks = listOf(FlowChunk(collectionIndex = 1, startState = ByteArray(0), eventCollection = ByteArray(0), blockId = FlowId("01"), totalComputationUsed = 1000L, numberOfTransactions = 10, index = 1L, endState = ByteArray(0), executionDataId = FlowId("02"), stateDeltaCommitment = ByteArray(0)))
-
-        val serviceEvents = listOf(FlowServiceEvent(type = "ServiceEventType", payload = ByteArray(0)))
-
-        val executionResult = FlowExecutionResult(blockId = FlowId("01"), previousResultId = FlowId("02"), chunks = chunks, serviceEvents = serviceEvents)
-
-        val grpcChunks = chunks.map {
-            ExecutionResultOuterClass.Chunk
-                .newBuilder()
-                .setCollectionIndex(it.collectionIndex)
-                .setStartState(ByteString.copyFrom(it.startState))
-                .setEventCollection(ByteString.copyFrom(it.eventCollection))
-                .setBlockId(ByteString.copyFrom(it.blockId.bytes))
-                .setTotalComputationUsed(it.totalComputationUsed)
-                .setNumberOfTransactions(it.numberOfTransactions)
-                .setIndex(it.index)
-                .setEndState(ByteString.copyFrom(it.endState))
-                .setExecutionDataId(ByteString.copyFrom(it.executionDataId.bytes))
-                .setStateDeltaCommitment(ByteString.copyFrom(it.stateDeltaCommitment))
-                .build()
-        }
-
-        val grpcServiceEvents = serviceEvents.map {
-            ExecutionResultOuterClass.ServiceEvent
-                .newBuilder()
-                .setType(it.type)
-                .setPayload(ByteString.copyFrom(it.payload))
-                .build()
-        }
-
-        val response = Access.ExecutionResultByIDResponse
-            .newBuilder()
-            .setExecutionResult(
-                ExecutionResultOuterClass.ExecutionResult
-                    .newBuilder()
-                    .setBlockId(ByteString.copyFrom(BLOCK_ID_BYTES))
-                    .setPreviousResultId(ByteString.copyFrom(PARENT_ID_BYTES))
-                    .addAllChunks(grpcChunks)
-                    .addAllServiceEvents(grpcServiceEvents)
-                    .build()
-            ).build()
-
-        `when`(api.getExecutionResultByID(any())).thenReturn(setupFutureMock(response))
-
-        val result = asyncFlowAccessApi.getExecutionResultByBlockId(blockId).get()
-        assert(result is FlowAccessApi.AccessApiCallResponse.Success)
-        result as FlowAccessApi.AccessApiCallResponse.Success
-        assertEquals(executionResult, result.data)
-    }
-
-    @Test
-    fun `test getTransactionsByBlockId timeout exception`() {
-        val blockId = FlowId("01")
-        val future: ListenableFuture<Access.TransactionsResponse> = SettableFuture.create()
-        `when`(api.getTransactionsByBlockID(any())).thenReturn(future)
-
-        val executor = Executors.newSingleThreadExecutor()
-        executor.submit {
-            assertThrows<TimeoutException> {
-                asyncFlowAccessApi.getTransactionsByBlockId(blockId).get(1, TimeUnit.SECONDS)
-            }
-        }
-
-        executor.shutdown()
-        executor.awaitTermination(2, TimeUnit.SECONDS)
     }
 }

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -81,7 +81,10 @@ class AsyncFlowAccessApiImplTest {
         val flowAddress = FlowAddress("01")
         val keyIndex = 0
         val mockAccountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
-        val response = Access.AccountKeyResponse.newBuilder().setAccountKey(mockAccountKey.builder().build()).build()
+        val response = Access.AccountKeyResponse
+            .newBuilder()
+            .setAccountKey(mockAccountKey.builder().build())
+            .build()
 
         `when`(api.getAccountKeyAtLatestBlock(any())).thenReturn(setupFutureMock(response))
 
@@ -112,7 +115,10 @@ class AsyncFlowAccessApiImplTest {
         val keyIndex = 0
         val blockHeight = HEIGHT
         val mockAccountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
-        val response = Access.AccountKeyResponse.newBuilder().setAccountKey(mockAccountKey.builder().build()).build()
+        val response = Access.AccountKeyResponse
+            .newBuilder()
+            .setAccountKey(mockAccountKey.builder().build())
+            .build()
 
         `when`(api.getAccountKeyAtBlockHeight(any())).thenReturn(setupFutureMock(response))
 
@@ -145,7 +151,8 @@ class AsyncFlowAccessApiImplTest {
             FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
             FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
         )
-        val response = Access.AccountKeysResponse.newBuilder()
+        val response = Access.AccountKeysResponse
+            .newBuilder()
             .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
             .build()
 
@@ -179,7 +186,8 @@ class AsyncFlowAccessApiImplTest {
             FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
             FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
         )
-        val response = Access.AccountKeysResponse.newBuilder()
+        val response = Access.AccountKeysResponse
+            .newBuilder()
             .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
             .build()
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -90,7 +90,8 @@ class FlowAccessApiImplTest {
         assertResultSuccess(result) { assertEquals(mockAccountKey, it) }
 
         verify(mockApi).getAccountKeyAtLatestBlock(
-            Access.GetAccountKeyAtLatestBlockRequest.newBuilder()
+            Access.GetAccountKeyAtLatestBlockRequest
+                .newBuilder()
                 .setAddress(flowAddress.byteStringValue)
                 .setIndex(keyIndex)
                 .build()
@@ -129,7 +130,8 @@ class FlowAccessApiImplTest {
         assertResultSuccess(result) { assertEquals(mockAccountKey, it) }
 
         verify(mockApi).getAccountKeyAtBlockHeight(
-            Access.GetAccountKeyAtBlockHeightRequest.newBuilder()
+            Access.GetAccountKeyAtBlockHeightRequest
+                .newBuilder()
                 .setAddress(flowAddress.byteStringValue)
                 .setIndex(keyIndex)
                 .setBlockHeight(blockHeight)
@@ -160,7 +162,8 @@ class FlowAccessApiImplTest {
             FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
             FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
         )
-        val response = Access.AccountKeysResponse.newBuilder()
+        val response = Access.AccountKeysResponse
+            .newBuilder()
             .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
             .build()
 
@@ -170,7 +173,8 @@ class FlowAccessApiImplTest {
         assertResultSuccess(result) { assertEquals(mockAccountKeys, it) }
 
         verify(mockApi).getAccountKeysAtLatestBlock(
-            Access.GetAccountKeysAtLatestBlockRequest.newBuilder()
+            Access.GetAccountKeysAtLatestBlockRequest
+                .newBuilder()
                 .setAddress(flowAddress.byteStringValue)
                 .build()
         )
@@ -198,7 +202,8 @@ class FlowAccessApiImplTest {
             FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
             FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
         )
-        val response = Access.AccountKeysResponse.newBuilder()
+        val response = Access.AccountKeysResponse
+            .newBuilder()
             .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
             .build()
 
@@ -208,7 +213,8 @@ class FlowAccessApiImplTest {
         assertResultSuccess(result) { assertEquals(mockAccountKeys, it) }
 
         verify(mockApi).getAccountKeysAtBlockHeight(
-            Access.GetAccountKeysAtBlockHeightRequest.newBuilder()
+            Access.GetAccountKeysAtBlockHeightRequest
+                .newBuilder()
                 .setAddress(flowAddress.byteStringValue)
                 .setBlockHeight(blockHeight)
                 .build()

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -75,6 +75,162 @@ class FlowAccessApiImplTest {
     }
 
     @Test
+    fun `Test getAccountKeyAtLatestBlock`() {
+        val flowAddress = FlowAddress("01")
+        val keyIndex = 0
+        val mockAccountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        val response = Access.AccountKeyResponse
+            .newBuilder()
+            .setAccountKey(mockAccountKey.builder().build())
+            .build()
+
+        `when`(mockApi.getAccountKeyAtLatestBlock(any())).thenReturn(response)
+
+        val result = flowAccessApiImpl.getAccountKeyAtLatestBlock(flowAddress, keyIndex)
+        assertResultSuccess(result) { assertEquals(mockAccountKey, it) }
+
+        verify(mockApi).getAccountKeyAtLatestBlock(
+            Access.GetAccountKeyAtLatestBlockRequest.newBuilder()
+                .setAddress(flowAddress.byteStringValue)
+                .setIndex(keyIndex)
+                .build()
+        )
+    }
+
+    @Test
+    fun `Test getAccountKeyAtLatestBlock error case`() {
+        val flowAddress = FlowAddress("01")
+        val keyIndex = 0
+        val exception = RuntimeException("Test exception")
+
+        `when`(mockApi.getAccountKeyAtLatestBlock(any())).thenThrow(exception)
+
+        val result = flowAccessApiImpl.getAccountKeyAtLatestBlock(flowAddress, keyIndex)
+
+        assertTrue(result is FlowAccessApi.AccessApiCallResponse.Error)
+        assertEquals("Failed to get account key at latest block", (result as FlowAccessApi.AccessApiCallResponse.Error).message)
+        assertEquals(exception, result.throwable)
+    }
+
+    @Test
+    fun `Test getAccountKeyAtBlockHeight`() {
+        val flowAddress = FlowAddress("01")
+        val keyIndex = 0
+        val blockHeight = 123L
+        val mockAccountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        val response = Access.AccountKeyResponse
+            .newBuilder()
+            .setAccountKey(mockAccountKey.builder().build())
+            .build()
+
+        `when`(mockApi.getAccountKeyAtBlockHeight(any())).thenReturn(response)
+
+        val result = flowAccessApiImpl.getAccountKeyAtBlockHeight(flowAddress, keyIndex, blockHeight)
+        assertResultSuccess(result) { assertEquals(mockAccountKey, it) }
+
+        verify(mockApi).getAccountKeyAtBlockHeight(
+            Access.GetAccountKeyAtBlockHeightRequest.newBuilder()
+                .setAddress(flowAddress.byteStringValue)
+                .setIndex(keyIndex)
+                .setBlockHeight(blockHeight)
+                .build()
+        )
+    }
+
+    @Test
+    fun `Test getAccountKeyAtBlockHeight error case`() {
+        val flowAddress = FlowAddress("01")
+        val keyIndex = 0
+        val blockHeight = 123L
+        val exception = RuntimeException("Test exception")
+
+        `when`(mockApi.getAccountKeyAtBlockHeight(any())).thenThrow(exception)
+
+        val result = flowAccessApiImpl.getAccountKeyAtBlockHeight(flowAddress, keyIndex, blockHeight)
+
+        assertTrue(result is FlowAccessApi.AccessApiCallResponse.Error)
+        assertEquals("Failed to get account key at block height", (result as FlowAccessApi.AccessApiCallResponse.Error).message)
+        assertEquals(exception, result.throwable)
+    }
+
+    @Test
+    fun `Test getAccountKeysAtLatestBlock`() {
+        val flowAddress = FlowAddress("01")
+        val mockAccountKeys = listOf(
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        )
+        val response = Access.AccountKeysResponse.newBuilder()
+            .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
+            .build()
+
+        `when`(mockApi.getAccountKeysAtLatestBlock(any())).thenReturn(response)
+
+        val result = flowAccessApiImpl.getAccountKeysAtLatestBlock(flowAddress)
+        assertResultSuccess(result) { assertEquals(mockAccountKeys, it) }
+
+        verify(mockApi).getAccountKeysAtLatestBlock(
+            Access.GetAccountKeysAtLatestBlockRequest.newBuilder()
+                .setAddress(flowAddress.byteStringValue)
+                .build()
+        )
+    }
+
+    @Test
+    fun `Test getAccountKeysAtLatestBlock error case`() {
+        val flowAddress = FlowAddress("01")
+        val exception = RuntimeException("Test exception")
+
+        `when`(mockApi.getAccountKeysAtLatestBlock(any())).thenThrow(exception)
+
+        val result = flowAccessApiImpl.getAccountKeysAtLatestBlock(flowAddress)
+
+        assertTrue(result is FlowAccessApi.AccessApiCallResponse.Error)
+        assertEquals("Failed to get account keys at latest block", (result as FlowAccessApi.AccessApiCallResponse.Error).message)
+        assertEquals(exception, result.throwable)
+    }
+
+    @Test
+    fun `Test getAccountKeysAtBlockHeight`() {
+        val flowAddress = FlowAddress("01")
+        val blockHeight = 123L
+        val mockAccountKeys = listOf(
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
+            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
+        )
+        val response = Access.AccountKeysResponse.newBuilder()
+            .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
+            .build()
+
+        `when`(mockApi.getAccountKeysAtBlockHeight(any())).thenReturn(response)
+
+        val result = flowAccessApiImpl.getAccountKeysAtBlockHeight(flowAddress, blockHeight)
+        assertResultSuccess(result) { assertEquals(mockAccountKeys, it) }
+
+        verify(mockApi).getAccountKeysAtBlockHeight(
+            Access.GetAccountKeysAtBlockHeightRequest.newBuilder()
+                .setAddress(flowAddress.byteStringValue)
+                .setBlockHeight(blockHeight)
+                .build()
+        )
+    }
+
+    @Test
+    fun `Test getAccountKeysAtBlockHeight error case`() {
+        val flowAddress = FlowAddress("01")
+        val blockHeight = 123L
+        val exception = RuntimeException("Test exception")
+
+        `when`(mockApi.getAccountKeysAtBlockHeight(any())).thenThrow(exception)
+
+        val result = flowAccessApiImpl.getAccountKeysAtBlockHeight(flowAddress, blockHeight)
+
+        assertTrue(result is FlowAccessApi.AccessApiCallResponse.Error)
+        assertEquals("Failed to get account keys at block height", (result as FlowAccessApi.AccessApiCallResponse.Error).message)
+        assertEquals(exception, result.throwable)
+    }
+
+    @Test
     fun `Test getLatestBlockHeader`() {
         val mockBlockHeader = mockBlockHeader
         val blockHeaderProto = Access.BlockHeaderResponse


### PR DESCRIPTION
Closes: #126 

## Description

- Add `GetAccountKeyAtLatestBlock, GetAccountKeysAtLatestBlock, GetAccountKeyAtBlockHeight and GetAccountKeysAtBlockHeight` methods to FlowAccessAPI
- Add above 4 methods to AsyncFlowAccessAPI
- Add new unit tests for above 4 methods
- Add new integration tests for above 4 methods
- Add examples for `getAccountKeys`
- Update examples docs with new methods

- Refactor `AsyncFlowAccessAPI` unit tests to remove code duplication where possible

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced methods for retrieving account keys at the latest block and specific block heights in both Java and Kotlin implementations.
	- Added functionality to fetch all account keys at the latest block and at specified block heights.
	- New feature to retrieve transaction results by index in both Java and Kotlin implementations.
	- Enhanced documentation to reflect new functionalities for account keys and transaction results in both Java and Kotlin examples.
- **Bug Fixes**
	- Enhanced error handling in API calls for retrieving account keys and transaction results.
- **Tests**
	- Added comprehensive test coverage for new account key retrieval methods and transaction result retrieval, including success and error scenarios across various test classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->