### PR TITLE
Get tx result by index endpoint

### DIFF
--- a/java-example/README.md
+++ b/java-example/README.md
@@ -80,6 +80,7 @@ Below is a list of all Java code examples currently supported in this repo:
 
 - Get transaction
 - Get transaction result
+- Get transaction result by index
 
 #### Sending Transactions
 

--- a/java-example/src/main/java/org/onflow/examples/java/getTransaction/GetTransactionAccessAPIConnector.java
+++ b/java-example/src/main/java/org/onflow/examples/java/getTransaction/GetTransactionAccessAPIConnector.java
@@ -31,4 +31,14 @@ public class GetTransactionAccessAPIConnector {
             throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
         }
     }
+
+    public FlowTransactionResult getTransactionResultByIndex(FlowId blockId, Integer index) {
+        FlowAccessApi.AccessApiCallResponse<FlowTransactionResult> response = accessAPI.getTransactionResultByIndex(blockId, index);
+        if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            return ((FlowAccessApi.AccessApiCallResponse.Success<FlowTransactionResult>) response).getData();
+        } else {
+            FlowAccessApi.AccessApiCallResponse.Error errorResponse = (FlowAccessApi.AccessApiCallResponse.Error) response;
+            throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
+        }
+    }
 }

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -81,6 +81,7 @@ Below is a list of all Kotlin code examples currently supported in this repo:
 
 - Get transaction 
 - Get transaction result
+- Get transaction result by index
 
 #### Sending Transactions
 

--- a/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnector.kt
+++ b/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnector.kt
@@ -16,4 +16,10 @@ class GetTransactionAccessAPIConnector(
             is FlowAccessApi.AccessApiCallResponse.Success -> response.data
             is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
         }
+
+    fun getTransactionResultByIndex(blockId: FlowId, index: Int): FlowTransactionResult =
+        when (val response = accessAPI.getTransactionResultByIndex(blockId, index)) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
 }

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnectorTest.kt
@@ -20,6 +20,7 @@ internal class GetTransactionAccessAPIConnectorTest {
     lateinit var accessAPI: FlowAccessApi
 
     private lateinit var connector: GetTransactionAccessAPIConnector
+    private lateinit var block: FlowBlock
     private lateinit var accessAPIConnector: AccessAPIConnector
 
     private lateinit var txID: FlowId
@@ -35,6 +36,11 @@ internal class GetTransactionAccessAPIConnectorTest {
             serviceAccount.flowAddress,
             publicKey
         )
+
+        block = when (val response = accessAPI.getLatestBlock()) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
     }
 
     @Test
@@ -48,6 +54,14 @@ internal class GetTransactionAccessAPIConnectorTest {
     @Test
     fun `Can fetch a transaction result`() {
         val transactionResult = connector.getTransactionResult(txID)
+
+        assertNotNull(transactionResult, "Transaction result should not be null")
+        assertTrue(transactionResult.status === FlowTransactionStatus.SEALED, "Transaction should be sealed")
+    }
+
+    @Test
+    fun `Can fetch a transaction result by index`() {
+        val transactionResult = connector.getTransactionResultByIndex(block.id, 0)
 
         assertNotNull(transactionResult, "Transaction result should not be null")
         assertTrue(transactionResult.status === FlowTransactionStatus.SEALED, "Transaction should be sealed")

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -162,13 +162,58 @@ class TransactionIntegrationTest {
     }
 
     @Test
+    fun `Can get transaction results`() {
+        val txResult = createAndSubmitAccountCreationTransaction(
+            accessAPI,
+            serviceAccount,
+            "cadence/transaction_creation/transaction_creation_simple_transaction.cdc"
+        )
+        assertThat(txResult).isNotNull
+        assertThat(txResult.status).isEqualTo(FlowTransactionStatus.SEALED)
+
+        val latestBlock = try {
+            handleResult(
+                accessAPI.getLatestBlock(true),
+                "Failed to get latest block"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve latest block: ${e.message}")
+        }
+
+        val txResultById = try {
+            handleResult(
+                accessAPI.getTransactionResultById(txResult.transactionId),
+                "Failed to get tx result by id"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve tx result by id: ${e.message}")
+        }
+
+        assertThat(txResultById).isNotNull
+        assertThat(txResultById.status).isEqualTo(FlowTransactionStatus.SEALED)
+        assertThat(txResultById.transactionId).isEqualTo(txResult.transactionId)
+
+        val txResultByIndex = try {
+            handleResult(
+                accessAPI.getTransactionResultByIndex(latestBlock.id, 0),
+                "Failed to get tx result by index"
+            )
+        } catch (e: Exception) {
+            fail("Failed to retrieve tx result by index: ${e.message}")
+        }
+
+        assertThat(txResultByIndex).isNotNull
+        assertThat(txResultByIndex.status).isEqualTo(FlowTransactionStatus.SEALED)
+        assertThat(txResultByIndex.transactionId).isEqualTo(txResultByIndex.transactionId)
+    }
+
+    @Test
     fun `Can parse events`() {
         val txResult = createAndSubmitAccountCreationTransaction(
             accessAPI,
             serviceAccount,
             "cadence/transaction_creation/transaction_creation_simple_transaction.cdc"
         )
-
         assertThat(txResult).isNotNull
         assertThat(txResult.status).isEqualTo(FlowTransactionStatus.SEALED)
 

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
@@ -38,7 +38,7 @@ interface AsyncFlowAccessApi {
 
     fun getTransactionResultById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult?>>
 
-    fun getTransactionResultByIndex(blockId: FlowId, index: Int) : CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>>
+    fun getTransactionResultByIndex(blockId: FlowId, index: Int): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>>
 
     @Deprecated(
         message = "Behaves identically to getAccountAtLatestBlock",

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
@@ -38,7 +38,7 @@ interface AsyncFlowAccessApi {
 
     fun getTransactionResultById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult?>>
 
-    fun getTransactionResultByIndex(blockId: FlowId, index: Int):  CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>>
+    fun getTransactionResultByIndex(blockId: FlowId, index: Int) : CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>>
 
     @Deprecated(
         message = "Behaves identically to getAccountAtLatestBlock",

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
@@ -38,6 +38,8 @@ interface AsyncFlowAccessApi {
 
     fun getTransactionResultById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult?>>
 
+    fun getTransactionResultByIndex(blockId: FlowId, index: Int):  CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>>
+
     @Deprecated(
         message = "Behaves identically to getAccountAtLatestBlock",
         replaceWith = ReplaceWith("getAccountAtLatestBlock")

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
@@ -50,6 +50,8 @@ interface FlowAccessApi {
 
     fun getTransactionResultById(id: FlowId): AccessApiCallResponse<FlowTransactionResult>
 
+    fun getTransactionResultByIndex(blockId: FlowId, index: Int): AccessApiCallResponse<FlowTransactionResult>
+
     @Deprecated(
         message = "Behaves identically to getAccountAtLatestBlock",
         replaceWith = ReplaceWith("getAccountAtLatestBlock")

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -476,6 +476,32 @@ class AsyncFlowAccessApiImpl(
         }
     }
 
+    override fun getTransactionResultByIndex(blockId: FlowId, index: Int): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>> {
+        return try {
+            completableFuture(
+                try {
+                    api.getTransactionResultByIndex(
+                        Access.GetTransactionByIndexRequest
+                            .newBuilder()
+                            .setBlockId(blockId.byteStringValue)
+                            .setIndex(index)
+                            .build()
+                    )
+                } catch (e: Exception) {
+                    return CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by index", e))
+                }
+            ).handle { response, ex ->
+                if (ex != null) {
+                    FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by index", ex)
+                } else {
+                    FlowAccessApi.AccessApiCallResponse.Success(FlowTransactionResult.of(response))
+                }
+            }
+        } catch (e: Exception) {
+            CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by index", e))
+        }
+    }
+
     @Deprecated("Behaves identically to getAccountAtLatestBlock", replaceWith = ReplaceWith("getAccountAtLatestBlock"))
     override fun getAccountByAddress(addresss: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> {
         return try {

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
@@ -276,7 +276,6 @@ class FlowAccessApiImpl(
             FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by ID", e)
         }
 
-
     override fun getTransactionResultByIndex(blockId: FlowId, index: Int): FlowAccessApi.AccessApiCallResponse<FlowTransactionResult> =
         try {
             val ret = api.getTransactionResultByIndex(

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
@@ -276,6 +276,21 @@ class FlowAccessApiImpl(
             FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by ID", e)
         }
 
+
+    override fun getTransactionResultByIndex(blockId: FlowId, index: Int): FlowAccessApi.AccessApiCallResponse<FlowTransactionResult> =
+        try {
+            val ret = api.getTransactionResultByIndex(
+                Access.GetTransactionByIndexRequest
+                    .newBuilder()
+                    .setBlockId(blockId.byteStringValue)
+                    .setIndex(index)
+                    .build()
+            )
+            FlowAccessApi.AccessApiCallResponse.Success(FlowTransactionResult.of(ret))
+        } catch (e: Exception) {
+            FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by index", e)
+        }
+
     @Deprecated("Behaves identically to getAccountAtLatestBlock", replaceWith = ReplaceWith("getAccountAtLatestBlock"))
     override fun getAccountByAddress(addresss: FlowAddress): FlowAccessApi.AccessApiCallResponse<FlowAccount> =
         try {

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
@@ -265,6 +265,20 @@ class FlowAccessApiTest {
     }
 
     @Test
+    fun `Test getTransactionResultByIndex`() {
+        val flowAccessApi = mock(FlowAccessApi::class.java)
+        val flowId = FlowId("01")
+        val index = 0
+
+        val flowTransactionResult = FlowTransactionResult.of(Access.TransactionResultResponse.getDefaultInstance())
+        `when`(flowAccessApi.getTransactionResultByIndex(flowId, index)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowTransactionResult))
+
+        val result = flowAccessApi.getTransactionResultByIndex(flowId, index)
+
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(flowTransactionResult), result)
+    }
+
+    @Test
     fun `Test getAccountAtLatestBlock`() {
         val flowAccessApi = mock(FlowAccessApi::class.java)
         val flowAddress = FlowAddress("01")


### PR DESCRIPTION
Closes: #132 

## Description
- Add `getTransactionResultByIndex` endpoint to FlowAccessAPI
- Add `getTransactionResultByIndex` endpoint to AsyncFlowAccessAPI
- Add unit tests for the above 2 classes
- Add integration tests for the endpoint
- Add examples for the endpoint 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
