### PR TITLE
Address code duplication in Access API tests and error handling

### DIFF
--- a/java-example/README.md
+++ b/java-example/README.md
@@ -70,6 +70,9 @@ Below is a list of all Java code examples currently supported in this repo:
 
 [Get collections by ID.](src/main/java/org/onflow/examples/java/getCollection/GetCollectionAccessAPIConnector.java)
 
+- Get collection by id
+- Get full collection by id (returns all transactions in collection response)
+
 #### Get Execution Data
 
 [Get execution data by block ID.](src/main/java/org/onflow/examples/java/getExecutionData/GetExecutionDataAccessAPIConnector.java)

--- a/java-example/src/main/java/org/onflow/examples/java/getCollection/GetCollectionAccessAPIConnector.java
+++ b/java-example/src/main/java/org/onflow/examples/java/getCollection/GetCollectionAccessAPIConnector.java
@@ -4,6 +4,9 @@ import org.onflow.flow.sdk.FlowAccessApi;
 import org.onflow.flow.sdk.FlowAccessApi.AccessApiCallResponse;
 import org.onflow.flow.sdk.FlowCollection;
 import org.onflow.flow.sdk.FlowId;
+import org.onflow.flow.sdk.FlowTransaction;
+
+import java.util.List;
 
 public class GetCollectionAccessAPIConnector {
     private final FlowAccessApi accessAPI;
@@ -16,6 +19,16 @@ public class GetCollectionAccessAPIConnector {
         AccessApiCallResponse<FlowCollection> response = accessAPI.getCollectionById(collectionId);
         if (response instanceof AccessApiCallResponse.Success) {
             return ((AccessApiCallResponse.Success<FlowCollection>) response).getData();
+        } else {
+            AccessApiCallResponse.Error errorResponse = (AccessApiCallResponse.Error) response;
+            throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
+        }
+    }
+
+    public List<FlowTransaction> getFullCollectionById(FlowId collectionId) {
+        AccessApiCallResponse<List<FlowTransaction>> response = accessAPI.getFullCollectionById(collectionId);
+        if (response instanceof AccessApiCallResponse.Success) {
+            return ((AccessApiCallResponse.Success<List<FlowTransaction>>) response).getData();
         } else {
             AccessApiCallResponse.Error errorResponse = (AccessApiCallResponse.Error) response;
             throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());

--- a/java-example/src/main/java/org/onflow/examples/java/getProtocolState/GetProtocolStateAccessAPIConnector.java
+++ b/java-example/src/main/java/org/onflow/examples/java/getProtocolState/GetProtocolStateAccessAPIConnector.java
@@ -1,0 +1,43 @@
+package org.onflow.examples.java.getProtocolState;
+
+import org.onflow.flow.sdk.FlowAccessApi;
+import org.onflow.flow.sdk.FlowId;
+import org.onflow.flow.sdk.FlowSnapshot;
+
+public class GetProtocolStateAccessAPIConnector {
+    private final FlowAccessApi accessAPI;
+
+    public GetProtocolStateAccessAPIConnector(FlowAccessApi accessAPI) {
+        this.accessAPI = accessAPI;
+    }
+
+    public FlowSnapshot getLatestProtocolStateSnapshot() {
+        FlowAccessApi.AccessApiCallResponse<FlowSnapshot> response = accessAPI.getLatestProtocolStateSnapshot();
+        if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            return ((FlowAccessApi.AccessApiCallResponse.Success<FlowSnapshot>) response).getData();
+        } else {
+            FlowAccessApi.AccessApiCallResponse.Error errorResponse = (FlowAccessApi.AccessApiCallResponse.Error) response;
+            throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
+        }
+    }
+
+    public FlowSnapshot getProtocolStateSnapshotByBlockId(FlowId blockId) {
+        FlowAccessApi.AccessApiCallResponse<FlowSnapshot> response = accessAPI.getProtocolStateSnapshotByBlockId(blockId);
+        if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            return ((FlowAccessApi.AccessApiCallResponse.Success<FlowSnapshot>) response).getData();
+        } else {
+            FlowAccessApi.AccessApiCallResponse.Error errorResponse = (FlowAccessApi.AccessApiCallResponse.Error) response;
+            throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
+        }
+    }
+
+    public FlowSnapshot getProtocolStateSnapshotByHeight(Long height) {
+        FlowAccessApi.AccessApiCallResponse<FlowSnapshot> response = accessAPI.getProtocolStateSnapshotByHeight(height);
+        if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            return ((FlowAccessApi.AccessApiCallResponse.Success<FlowSnapshot>) response).getData();
+        } else {
+            FlowAccessApi.AccessApiCallResponse.Error errorResponse = (FlowAccessApi.AccessApiCallResponse.Error) response;
+            throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
+        }
+    }
+}

--- a/java-example/src/test/java/org/onflow/examples/java/getCollection/GetCollectionAccessAPIConnectorTest.java
+++ b/java-example/src/test/java/org/onflow/examples/java/getCollection/GetCollectionAccessAPIConnectorTest.java
@@ -11,6 +11,8 @@ import org.onflow.flow.sdk.*;
 import org.onflow.flow.sdk.crypto.Crypto;
 import org.onflow.flow.sdk.crypto.PublicKey;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
@@ -50,5 +52,17 @@ public class GetCollectionAccessAPIConnectorTest {
 
         assertNotNull(collection, "Collection should not be null");
         assertEquals(collectionId, collection.getId(), "Collection ID should match the fetched collection ID");
+    }
+
+    @Test
+    public void canFetchFullCollectionById() {
+        List<FlowTransaction> fullCollectionResponse = connector.getFullCollectionById(collectionId);
+
+        assertNotNull(fullCollectionResponse, "Collection transactions should not be null");
+        assertFalse(fullCollectionResponse.isEmpty(), "Collection transactions should not be empty");
+
+        FlowTransaction firstTransaction = fullCollectionResponse.get(0);
+        assertNotNull(firstTransaction.getId(), "Transaction ID should not be null");
+        assertNotNull(firstTransaction.getScript(), "Transaction script should not be null");
     }
 }

--- a/java-example/src/test/java/org/onflow/examples/java/getProtocolState/GetProtocolStateAccessAPIConnectorTest.java
+++ b/java-example/src/test/java/org/onflow/examples/java/getProtocolState/GetProtocolStateAccessAPIConnectorTest.java
@@ -1,0 +1,55 @@
+package org.onflow.examples.java.getProtocolState;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.onflow.flow.common.test.FlowEmulatorProjectTest;
+import org.onflow.flow.common.test.FlowTestClient;
+import org.onflow.flow.sdk.FlowAccessApi;
+import org.onflow.flow.sdk.FlowBlock;
+import org.onflow.flow.sdk.FlowSnapshot;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
+public class GetProtocolStateAccessAPIConnectorTest {
+    @FlowTestClient
+    private FlowAccessApi accessAPI;
+    private FlowBlock block;
+
+    private GetProtocolStateAccessAPIConnector protocolStateConnector;
+
+    @BeforeEach
+    public void setup() {
+        protocolStateConnector = new GetProtocolStateAccessAPIConnector(accessAPI);
+    }
+
+    @Test
+    public void canGetLatestProtocolStateSnapshot() {
+        FlowSnapshot latestSnapshot = protocolStateConnector.getLatestProtocolStateSnapshot();
+        assertNotNull(latestSnapshot, "Latest snapshot should not be null");
+    }
+
+    @Test
+    public void canGetProtocolStateSnapshotByBlockId() {
+        block = getLatestBlock();
+        FlowSnapshot snapshot = protocolStateConnector.getProtocolStateSnapshotByBlockId(block.getId());
+        assertNotNull(snapshot, "Snapshot should not be null");
+    }
+
+    @Test
+    public void canGetProtocolStateSnapshotByHeight() {
+        block = getLatestBlock();
+        FlowSnapshot snapshot = protocolStateConnector.getProtocolStateSnapshotByHeight(block.getHeight());
+        assertNotNull(snapshot, "Snapshot should not be null");
+    }
+
+    private FlowBlock getLatestBlock() {
+        FlowAccessApi.AccessApiCallResponse<FlowBlock> response = accessAPI.getLatestBlock(true, false);
+        if (response instanceof FlowAccessApi.AccessApiCallResponse.Success) {
+            return ((FlowAccessApi.AccessApiCallResponse.Success<FlowBlock>) response).getData();
+        } else {
+            FlowAccessApi.AccessApiCallResponse.Error errorResponse = (FlowAccessApi.AccessApiCallResponse.Error) response;
+            throw new RuntimeException(errorResponse.getMessage(), errorResponse.getThrowable());
+        }
+    }
+}

--- a/kotlin-example/README.md
+++ b/kotlin-example/README.md
@@ -71,6 +71,9 @@ Below is a list of all Kotlin code examples currently supported in this repo:
 
 [Get collections by ID.](src/main/kotlin/org/onflow/examples/kotlin/getCollection/GetCollectionAccessAPIConnector.kt)
 
+- Get collection by id
+- Get full collection by id (returns all transactions in collection response)
+
 #### Get Execution Data
 
 [Get execution data by block ID.](src/main/kotlin/org/onflow/examples/kotlin/getExecutionData/GetExecutionDataAccessAPIConnector.kt)

--- a/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getCollection/GetCollectionAccessAPIConnector.kt
+++ b/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getCollection/GetCollectionAccessAPIConnector.kt
@@ -11,4 +11,10 @@ class GetCollectionAccessAPIConnector(
             is AccessApiCallResponse.Success -> response.data
             is AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
         }
+
+    fun getFullCollectionById(collectionId: FlowId): List<FlowTransaction> =
+        when (val response = accessAPI.getFullCollectionById(collectionId)) {
+            is AccessApiCallResponse.Success -> response.data
+            is AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
 }

--- a/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getProtocolState/GetProtocolStateAccessAPIConnector.kt
+++ b/kotlin-example/src/main/kotlin/org/onflow/examples/kotlin/getProtocolState/GetProtocolStateAccessAPIConnector.kt
@@ -1,0 +1,27 @@
+package org.onflow.examples.kotlin.getProtocolState
+
+import org.onflow.flow.sdk.FlowAccessApi
+import org.onflow.flow.sdk.FlowId
+import org.onflow.flow.sdk.FlowSnapshot
+
+internal class GetProtocolStateAccessAPIConnector(
+    private val accessAPI: FlowAccessApi
+) {
+    fun getLatestProtocolStateSnapshot(): FlowSnapshot =
+        when (val response = accessAPI.getLatestProtocolStateSnapshot()) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
+
+    fun getProtocolStateSnapshotByBlockId(blockId: FlowId): FlowSnapshot =
+        when (val response = accessAPI.getProtocolStateSnapshotByBlockId(blockId)) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
+
+    fun getProtocolStateSnapshotByHeight(height: Long): FlowSnapshot =
+        when (val response = accessAPI.getProtocolStateSnapshotByHeight(height)) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
+}

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getCollection/GetCollectionAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getCollection/GetCollectionAccessAPIConnectorTest.kt
@@ -8,10 +8,7 @@ import org.onflow.flow.common.test.FlowEmulatorProjectTest
 import org.onflow.flow.common.test.FlowServiceAccountCredentials
 import org.onflow.flow.common.test.FlowTestClient
 import org.onflow.flow.common.test.TestAccount
-import org.onflow.flow.sdk.FlowAccessApi
-import org.onflow.flow.sdk.FlowCollection
-import org.onflow.flow.sdk.FlowId
-import org.onflow.flow.sdk.SignatureAlgorithm
+import org.onflow.flow.sdk.*
 import org.onflow.flow.sdk.crypto.Crypto
 
 @FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
@@ -52,5 +49,17 @@ class GetCollectionAccessAPIConnectorTest {
 
         assertNotNull(collection, "Collection should not be null")
         assertEquals(collectionId, collection.id, "Collection ID should match the fetched collection ID")
+    }
+
+    @Test
+    fun `Can fetch full collection by ID`() {
+        val collectionTransactions: List<FlowTransaction> = connector.getFullCollectionById(collectionId)
+
+        assertNotNull(collectionTransactions, "Collection transactions should not be null")
+        assertTrue(collectionTransactions.isNotEmpty(), "Collection transactions should not be empty")
+
+        val firstTransaction = collectionTransactions.first()
+        assertNotNull(firstTransaction.id, "Transaction ID should not be null")
+        assertNotNull(firstTransaction.script, "Transaction script should not be null")
     }
 }

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getNetworkParams/GetNetworkParamsAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getNetworkParams/GetNetworkParamsAccessAPIConnectorTest.kt
@@ -3,13 +3,14 @@ package org.onflow.examples.kotlin.getNetworkParams
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.onflow.examples.kotlin.getProtocolState.GetProtocolStateAccessAPIConnector
 import org.onflow.flow.common.test.FlowEmulatorProjectTest
 import org.onflow.flow.common.test.FlowTestClient
 import org.onflow.flow.sdk.FlowAccessApi
 import org.onflow.flow.sdk.FlowChainId
 
 @FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
-internal class GetNetworkParametersAccessAPIConnectorTest {
+internal class GetNetworkParamsAccessAPIConnectorTest {
     @FlowTestClient
     lateinit var accessAPI: FlowAccessApi
 

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getNetworkParams/GetNetworkParamsAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getNetworkParams/GetNetworkParamsAccessAPIConnectorTest.kt
@@ -3,7 +3,6 @@ package org.onflow.examples.kotlin.getNetworkParams
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.onflow.examples.kotlin.getProtocolState.GetProtocolStateAccessAPIConnector
 import org.onflow.flow.common.test.FlowEmulatorProjectTest
 import org.onflow.flow.common.test.FlowTestClient
 import org.onflow.flow.sdk.FlowAccessApi

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getProtocolState/GetProtocolStateAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getProtocolState/GetProtocolStateAccessAPIConnectorTest.kt
@@ -30,7 +30,6 @@ internal class GetProtocolStateAccessAPIConnectorTest {
 
     @Test
     fun `Can get protocol state snapshot by blockId`() {
-
         block = when (val response = accessAPI.getLatestBlock()) {
             is FlowAccessApi.AccessApiCallResponse.Success -> response.data
             is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
@@ -42,7 +41,6 @@ internal class GetProtocolStateAccessAPIConnectorTest {
 
     @Test
     fun `Can get protocol state snapshot by height`() {
-
         block = when (val response = accessAPI.getLatestBlock()) {
             is FlowAccessApi.AccessApiCallResponse.Success -> response.data
             is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getProtocolState/GetProtocolStateAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getProtocolState/GetProtocolStateAccessAPIConnectorTest.kt
@@ -1,0 +1,54 @@
+package org.onflow.examples.kotlin.getProtocolState
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.onflow.flow.common.test.FlowEmulatorProjectTest
+import org.onflow.flow.common.test.FlowTestClient
+import org.onflow.flow.sdk.FlowAccessApi
+import org.onflow.flow.sdk.FlowBlock
+import org.onflow.flow.sdk.FlowSnapshot
+
+@FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
+internal class GetProtocolStateAccessAPIConnectorTest {
+    @FlowTestClient
+    lateinit var accessAPI: FlowAccessApi
+    lateinit var block: FlowBlock
+
+    private lateinit var protocolStateConnector: GetProtocolStateAccessAPIConnector
+
+    @BeforeEach
+    fun setup() {
+        protocolStateConnector = GetProtocolStateAccessAPIConnector(accessAPI)
+    }
+
+    @Test
+    fun `Can get latest protocol state snapshot`() {
+        val latestSnapshot: FlowSnapshot = protocolStateConnector.getLatestProtocolStateSnapshot()
+        assertNotNull(latestSnapshot, "Latest snapshot should not be null")
+    }
+
+    @Test
+    fun `Can get protocol state snapshot by blockId`() {
+
+        block = when (val response = accessAPI.getLatestBlock()) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
+
+        val latestSnapshot: FlowSnapshot = protocolStateConnector.getProtocolStateSnapshotByBlockId(block.id)
+        assertNotNull(latestSnapshot, ("Snapshot should not be null"))
+    }
+
+    @Test
+    fun `Can get protocol state snapshot by height`() {
+
+        block = when (val response = accessAPI.getLatestBlock()) {
+            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
+            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
+        }
+
+        val latestSnapshot: FlowSnapshot = protocolStateConnector.getProtocolStateSnapshotByHeight(block.height)
+        assertNotNull(latestSnapshot, ("Snapshot should not be null"))
+    }
+}

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -19,42 +19,69 @@ class TransactionIntegrationTest {
     @FlowServiceAccountCredentials
     lateinit var serviceAccount: TestAccount
 
+    private companion object {
+        const val LATEST_BLOCK_ERROR = "Failed to get latest block"
+        const val ACCOUNT_ERROR = "Failed to get account"
+        const val ACCOUNT_BALANCE_ERROR = "Failed to get account balance"
+        const val BLOCK_HEADER_ERROR = "Failed to get block header"
+        const val ACCOUNT_KEYS_ERROR = "Failed to get account keys"
+        const val ACCOUNT_KEY_ERROR = "Failed to get account key"
+        const val TRANSACTION_RESULT_ERROR = "Failed to get transaction result"
+        const val NODE_VERSION_INFO_ERROR = "Failed to get node version info"
+        const val ACCOUNT_BALANCE_LATEST_ERROR = "Failed to get account balance at latest block"
+        const val ACCOUNT_BALANCE_BLOCK_HEIGHT_ERROR = "Failed to get account balance at block height"
+        const val BLOCK_ID_ERROR = "Failed to get block by ID"
+        const val BLOCK_HEIGHT_ERROR = "Failed to get block by height"
+        const val ACCOUNT_BY_ADDRESS_ERROR = "Failed to get account by address"
+        const val ACCOUNT_AT_LATEST_BLOCK_ERROR = "Failed to get account at latest block"
+        const val ACCOUNT_BY_BLOCK_HEIGHT_ERROR = "Failed to get account by block height"
+    }
+
     private fun <T> safelyHandle(action: () -> Result<T>, errorMessage: String): T =
         action().getOrElse { e ->
             fail("$errorMessage: ${e.message}")
         }
 
     private fun getLatestBlock(): FlowBlock =
-        safelyHandle({ Result.success(handleResult(accessAPI.getLatestBlock(true), "Failed to get latest block")) }, "Failed to retrieve latest block")
+        safelyHandle({ Result.success(handleResult(accessAPI.getLatestBlock(true), LATEST_BLOCK_ERROR)) }, LATEST_BLOCK_ERROR)
 
     private fun getAccountAtLatestBlock(address: FlowAddress): FlowAccount =
-        safelyHandle({ Result.success(handleResult(accessAPI.getAccountAtLatestBlock(address), "Failed to get account at latest block")) }, "Failed to retrieve account at latest block")
+        safelyHandle({ Result.success(handleResult(accessAPI.getAccountAtLatestBlock(address), ACCOUNT_ERROR)) }, ACCOUNT_ERROR)
 
     private fun getAccountBalanceAtBlockHeight(address: FlowAddress, height: Long): Long =
-        safelyHandle({ Result.success(handleResult(accessAPI.getAccountBalanceAtBlockHeight(address, height), "Failed to get account balance at block height")) }, "Failed to retrieve account balance at block height")
+        safelyHandle({ Result.success(handleResult(accessAPI.getAccountBalanceAtBlockHeight(address, height), ACCOUNT_BALANCE_ERROR)) }, ACCOUNT_BALANCE_ERROR)
 
     private fun getBlockHeaderByHeight(height: Long): FlowBlockHeader =
-        safelyHandle({ Result.success(handleResult(accessAPI.getBlockHeaderByHeight(height), "Failed to get block header by height")) }, "Failed to retrieve block header by height")
+        safelyHandle({ Result.success(handleResult(accessAPI.getBlockHeaderByHeight(height), BLOCK_HEADER_ERROR)) }, BLOCK_HEADER_ERROR)
 
     private fun getAccountKeysAtLatestBlock(address: FlowAddress): List<FlowAccountKey> =
-        safelyHandle({ Result.success(handleResult(accessAPI.getAccountKeysAtLatestBlock(address), "Failed to get account keys at latest block")) }, "Failed to retrieve account keys at latest block")
+        safelyHandle({ Result.success(handleResult(accessAPI.getAccountKeysAtLatestBlock(address), ACCOUNT_KEYS_ERROR)) }, ACCOUNT_KEYS_ERROR)
 
     private fun getAccountKeyAtBlockHeight(address: FlowAddress, keyIndex: Int, height: Long): FlowAccountKey =
-        safelyHandle({ Result.success(handleResult(accessAPI.getAccountKeyAtBlockHeight(address, keyIndex, height), "Failed to get account key at block height")) }, "Failed to retrieve account key at block height")
+        safelyHandle({ Result.success(handleResult(accessAPI.getAccountKeyAtBlockHeight(address, keyIndex, height), ACCOUNT_KEY_ERROR)) }, ACCOUNT_KEY_ERROR)
 
     private fun getBlockHeaderById(blockId: FlowId): FlowBlockHeader =
-        safelyHandle({ Result.success(handleResult(accessAPI.getBlockHeaderById(blockId), "Failed to get block header by ID")) }, "Failed to retrieve block header by ID")
+        safelyHandle({ Result.success(handleResult(accessAPI.getBlockHeaderById(blockId), BLOCK_ID_ERROR)) }, BLOCK_ID_ERROR)
 
     private fun getTransactionResultById(transactionId: FlowId): FlowTransactionResult =
-        safelyHandle({ Result.success(handleResult(accessAPI.getTransactionResultById(transactionId), "Failed to get transaction result by ID")) }, "Failed to retrieve transaction result by ID")
+        safelyHandle({ Result.success(handleResult(accessAPI.getTransactionResultById(transactionId), TRANSACTION_RESULT_ERROR)) }, TRANSACTION_RESULT_ERROR)
 
     private fun getTransactionResultByIndex(blockId: FlowId, index: Int): FlowTransactionResult =
-        safelyHandle({ Result.success(handleResult(accessAPI.getTransactionResultByIndex(blockId, index), "Failed to get transaction result by index")) }, "Failed to retrieve transaction result by index")
-
+        safelyHandle({ Result.success(handleResult(accessAPI.getTransactionResultByIndex(blockId, index), TRANSACTION_RESULT_ERROR)) }, TRANSACTION_RESULT_ERROR)
 
     @Test
     fun `Can connect to emulator and ping access API`() {
-        safelyHandle({ handleResult(accessAPI.ping(), "Failed to ping") }, "Failed to ping emulator")
+        safelyHandle(
+            {
+                try {
+                    accessAPI.ping()
+                    Result.success(Unit)
+                } catch (e: Exception) {
+                    Result.failure(e)
+                }
+            },
+            "Failed to ping emulator"
+        )
 
         val account = getAccountAtLatestBlock(serviceAccount.flowAddress)
         assertThat(account).isNotNull
@@ -64,8 +91,8 @@ class TransactionIntegrationTest {
     @Test
     fun `Can get network parameters`() {
         val networkParams = safelyHandle(
-            { Result.success(handleResult(accessAPI.getNetworkParameters(), "Failed to get network parameters")) },
-            "Failed to retrieve network parameters"
+            { Result.success(handleResult(accessAPI.getNetworkParameters(), NODE_VERSION_INFO_ERROR)) },
+            NODE_VERSION_INFO_ERROR
         )
 
         assertThat(networkParams).isEqualTo(FlowChainId.EMULATOR)
@@ -74,8 +101,8 @@ class TransactionIntegrationTest {
     @Test
     fun `Can get account key at latest block`() {
         val accountKey = safelyHandle(
-            { Result.success(handleResult(accessAPI.getAccountKeyAtLatestBlock(serviceAccount.flowAddress, 0), "Failed to get account key at latest block")) },
-            "Failed to retrieve account key at latest block"
+            { Result.success(handleResult(accessAPI.getAccountKeyAtLatestBlock(serviceAccount.flowAddress, 0), ACCOUNT_KEY_ERROR)) },
+            ACCOUNT_KEY_ERROR
         )
 
         assertThat(accountKey).isNotNull
@@ -190,8 +217,8 @@ class TransactionIntegrationTest {
         val address = serviceAccount.flowAddress
 
         val balanceResponse = safelyHandle(
-            { Result.success(handleResult(accessAPI.getAccountBalanceAtLatestBlock(address), "Failed to get account balance at latest block")) },
-            "Failed to retrieve account balance at latest block"
+            { Result.success(handleResult(accessAPI.getAccountBalanceAtLatestBlock(address), ACCOUNT_BALANCE_LATEST_ERROR)) },
+            ACCOUNT_BALANCE_LATEST_ERROR
         )
 
         val account = getAccountAtLatestBlock(address)
@@ -206,8 +233,8 @@ class TransactionIntegrationTest {
         val balanceResponse = getAccountBalanceAtBlockHeight(serviceAccount.flowAddress, latestBlock.height)
 
         val account = safelyHandle(
-            { Result.success(handleResult(accessAPI.getAccountByBlockHeight(serviceAccount.flowAddress, latestBlock.height), "Failed to get account by block height")) },
-            "Failed to retrieve account by block height"
+            { Result.success(handleResult(accessAPI.getAccountByBlockHeight(serviceAccount.flowAddress, latestBlock.height), ACCOUNT_BY_BLOCK_HEIGHT_ERROR)) },
+            ACCOUNT_BY_BLOCK_HEIGHT_ERROR
         )
 
         val normalizedBalance = balanceResponse / 100_000_000L
@@ -217,8 +244,8 @@ class TransactionIntegrationTest {
     @Test
     fun `Can get latest block`() {
         val latestBlock = safelyHandle(
-            { Result.success(handleResult(accessAPI.getLatestBlock(true), "Failed to get latest block")) },
-            "Failed to retrieve latest block"
+            { Result.success(handleResult(accessAPI.getLatestBlock(true), LATEST_BLOCK_ERROR)) },
+            LATEST_BLOCK_ERROR
         )
 
         assertThat(latestBlock).isNotNull
@@ -229,8 +256,8 @@ class TransactionIntegrationTest {
         val latestBlock = getLatestBlock()
 
         val blockById = safelyHandle(
-            { Result.success(handleResult(accessAPI.getBlockById(latestBlock.id), "Failed to get block by ID")) },
-            "Failed to retrieve block by ID"
+            { Result.success(handleResult(accessAPI.getBlockById(latestBlock.id), BLOCK_ID_ERROR)) },
+            BLOCK_ID_ERROR
         )
 
         assertThat(blockById).isNotNull
@@ -241,8 +268,8 @@ class TransactionIntegrationTest {
     fun `Can get block by height`() {
         val latestBlock = getLatestBlock()
         val blockByHeight = safelyHandle(
-            { Result.success(handleResult(accessAPI.getBlockByHeight(latestBlock.height), "Failed to get block by height")) },
-            "Failed to retrieve block by height"
+            { Result.success(handleResult(accessAPI.getBlockByHeight(latestBlock.height), BLOCK_HEIGHT_ERROR)) },
+            BLOCK_HEIGHT_ERROR
         )
 
         assertThat(blockByHeight).isNotNull
@@ -253,8 +280,8 @@ class TransactionIntegrationTest {
     fun `Can get account by address`() {
         val address = serviceAccount.flowAddress
         val account = safelyHandle(
-            { Result.success(handleResult(accessAPI.getAccountByAddress(address), "Failed to get account by address")) },
-            "Failed to retrieve account by address"
+            { Result.success(handleResult(accessAPI.getAccountByAddress(address), ACCOUNT_BY_ADDRESS_ERROR)) },
+            ACCOUNT_BY_ADDRESS_ERROR
         )
 
         assertThat(account).isNotNull
@@ -265,8 +292,8 @@ class TransactionIntegrationTest {
     fun `Can get account by address at latest block`() {
         val address = serviceAccount.flowAddress
         val account = safelyHandle(
-            { Result.success(handleResult(accessAPI.getAccountAtLatestBlock(address), "Failed to get account at latest block")) },
-            "Failed to retrieve account at latest block"
+            { Result.success(handleResult(accessAPI.getAccountAtLatestBlock(address), ACCOUNT_AT_LATEST_BLOCK_ERROR)) },
+            ACCOUNT_AT_LATEST_BLOCK_ERROR
         )
 
         assertThat(account).isNotNull
@@ -277,8 +304,8 @@ class TransactionIntegrationTest {
     fun `Can get account by block height`() {
         val latestBlock = getLatestBlock()
         val account = safelyHandle(
-            { Result.success(handleResult(accessAPI.getAccountByBlockHeight(serviceAccount.flowAddress, latestBlock.height), "Failed to get account by block height")) },
-            "Failed to retrieve account by block height"
+            { Result.success(handleResult(accessAPI.getAccountByBlockHeight(serviceAccount.flowAddress, latestBlock.height), ACCOUNT_BY_BLOCK_HEIGHT_ERROR)) },
+            ACCOUNT_BY_BLOCK_HEIGHT_ERROR
         )
 
         assertThat(account).isNotNull

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -32,7 +32,6 @@ class TransactionIntegrationTest {
         const val BLOCK_ID_ERROR = "Failed to get block by ID"
         const val BLOCK_HEIGHT_ERROR = "Failed to get block by height"
         const val ACCOUNT_BY_ADDRESS_ERROR = "Failed to get account by address"
-        const val ACCOUNT_AT_LATEST_BLOCK_ERROR = "Failed to get account at latest block"
         const val ACCOUNT_BY_BLOCK_HEIGHT_ERROR = "Failed to get account by block height"
     }
 

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -196,6 +196,7 @@ class TransactionIntegrationTest {
         assertThat(blockHeader).isNotNull
         assertThat(blockHeader.height).isEqualTo(latestBlock.height)
     }
+
     @Test
     fun `Can get block header by height`() {
         val latestBlock = getLatestBlock()
@@ -233,7 +234,6 @@ class TransactionIntegrationTest {
         val normalizedBalance = balanceResponse / 100_000_000L
         assertThat(normalizedBalance).isEqualTo(account.balance.toBigInteger().longValueExact())
     }
-
 
     @Test
     fun `Can get latest block`() {

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -19,60 +19,38 @@ class TransactionIntegrationTest {
     @FlowServiceAccountCredentials
     lateinit var serviceAccount: TestAccount
 
-    private fun <T> safelyHandle(action: () -> T, errorMessage: String): T =
-        try {
-            action()
-        } catch (e: Exception) {
+    private fun <T> safelyHandle(action: () -> Result<T>, errorMessage: String): T =
+        action().getOrElse { e ->
             fail("$errorMessage: ${e.message}")
         }
 
     private fun getLatestBlock(): FlowBlock =
-        safelyHandle({ handleResult(accessAPI.getLatestBlock(true), "Failed to get latest block") }, "Failed to retrieve latest block")
+        safelyHandle({ Result.success(handleResult(accessAPI.getLatestBlock(true), "Failed to get latest block")) }, "Failed to retrieve latest block")
 
     private fun getAccountAtLatestBlock(address: FlowAddress): FlowAccount =
-        safelyHandle({ handleResult(accessAPI.getAccountAtLatestBlock(address), "Failed to get account at latest block") }, "Failed to retrieve account at latest block")
+        safelyHandle({ Result.success(handleResult(accessAPI.getAccountAtLatestBlock(address), "Failed to get account at latest block")) }, "Failed to retrieve account at latest block")
 
     private fun getAccountBalanceAtBlockHeight(address: FlowAddress, height: Long): Long =
-        safelyHandle(
-            { handleResult(accessAPI.getAccountBalanceAtBlockHeight(address, height), "Failed to get account balance at block height") },
-            "Failed to retrieve account balance at block height"
-        )
+        safelyHandle({ Result.success(handleResult(accessAPI.getAccountBalanceAtBlockHeight(address, height), "Failed to get account balance at block height")) }, "Failed to retrieve account balance at block height")
 
     private fun getBlockHeaderByHeight(height: Long): FlowBlockHeader =
-        safelyHandle(
-            { handleResult(accessAPI.getBlockHeaderByHeight(height), "Failed to get block header by height") },
-            "Failed to retrieve block header by height"
-        )
+        safelyHandle({ Result.success(handleResult(accessAPI.getBlockHeaderByHeight(height), "Failed to get block header by height")) }, "Failed to retrieve block header by height")
 
     private fun getAccountKeysAtLatestBlock(address: FlowAddress): List<FlowAccountKey> =
-        safelyHandle(
-            { handleResult(accessAPI.getAccountKeysAtLatestBlock(address), "Failed to get account keys at latest block") },
-            "Failed to retrieve account keys at latest block"
-        )
+        safelyHandle({ Result.success(handleResult(accessAPI.getAccountKeysAtLatestBlock(address), "Failed to get account keys at latest block")) }, "Failed to retrieve account keys at latest block")
 
     private fun getAccountKeyAtBlockHeight(address: FlowAddress, keyIndex: Int, height: Long): FlowAccountKey =
-        safelyHandle(
-            { handleResult(accessAPI.getAccountKeyAtBlockHeight(address, keyIndex, height), "Failed to get account key at block height") },
-            "Failed to retrieve account key at block height"
-        )
+        safelyHandle({ Result.success(handleResult(accessAPI.getAccountKeyAtBlockHeight(address, keyIndex, height), "Failed to get account key at block height")) }, "Failed to retrieve account key at block height")
 
     private fun getBlockHeaderById(blockId: FlowId): FlowBlockHeader =
-        safelyHandle(
-            { handleResult(accessAPI.getBlockHeaderById(blockId), "Failed to get block header by ID") },
-            "Failed to retrieve block header by ID"
-        )
+        safelyHandle({ Result.success(handleResult(accessAPI.getBlockHeaderById(blockId), "Failed to get block header by ID")) }, "Failed to retrieve block header by ID")
 
     private fun getTransactionResultById(transactionId: FlowId): FlowTransactionResult =
-        safelyHandle(
-            { handleResult(accessAPI.getTransactionResultById(transactionId), "Failed to get transaction result by ID") },
-            "Failed to retrieve transaction result by ID"
-        )
+        safelyHandle({ Result.success(handleResult(accessAPI.getTransactionResultById(transactionId), "Failed to get transaction result by ID")) }, "Failed to retrieve transaction result by ID")
 
     private fun getTransactionResultByIndex(blockId: FlowId, index: Int): FlowTransactionResult =
-        safelyHandle(
-            { handleResult(accessAPI.getTransactionResultByIndex(blockId, index), "Failed to get transaction result by index") },
-            "Failed to retrieve transaction result by index"
-        )
+        safelyHandle({ Result.success(handleResult(accessAPI.getTransactionResultByIndex(blockId, index), "Failed to get transaction result by index")) }, "Failed to retrieve transaction result by index")
+
 
     @Test
     fun `Can connect to emulator and ping access API`() {
@@ -86,7 +64,7 @@ class TransactionIntegrationTest {
     @Test
     fun `Can get network parameters`() {
         val networkParams = safelyHandle(
-            { handleResult(accessAPI.getNetworkParameters(), "Failed to get network parameters") },
+            { Result.success(handleResult(accessAPI.getNetworkParameters(), "Failed to get network parameters")) },
             "Failed to retrieve network parameters"
         )
 
@@ -96,12 +74,12 @@ class TransactionIntegrationTest {
     @Test
     fun `Can get account key at latest block`() {
         val accountKey = safelyHandle(
-            { handleResult(accessAPI.getAccountKeyAtLatestBlock(serviceAccount.flowAddress, 0), "Failed to get account key at latest block") },
+            { Result.success(handleResult(accessAPI.getAccountKeyAtLatestBlock(serviceAccount.flowAddress, 0), "Failed to get account key at latest block")) },
             "Failed to retrieve account key at latest block"
         )
 
         assertThat(accountKey).isNotNull
-        assertThat(accountKey.sequenceNumber).isEqualTo(0)
+        assertThat(accountKey!!.sequenceNumber).isEqualTo(0)
     }
 
     @Test
@@ -127,7 +105,7 @@ class TransactionIntegrationTest {
         val latestBlock = getLatestBlock()
 
         val accountKeys = safelyHandle(
-            { handleResult(accessAPI.getAccountKeysAtBlockHeight(address, latestBlock.height), "Failed to get account keys at block height") },
+            { Result.success(handleResult(accessAPI.getAccountKeysAtBlockHeight(address, latestBlock.height), "Failed to get account keys at block height")) },
             "Failed to retrieve account keys at block height"
         )
 
@@ -138,7 +116,7 @@ class TransactionIntegrationTest {
     @Test
     fun `Can get node version info`() {
         val nodeVersionInfo = safelyHandle(
-            { handleResult(accessAPI.getNodeVersionInfo(), "Failed to get node version info") },
+            { Result.success(handleResult(accessAPI.getNodeVersionInfo(), "Failed to get node version info")) },
             "Failed to retrieve node version info"
         )
 
@@ -148,6 +126,7 @@ class TransactionIntegrationTest {
         assertThat(nodeVersionInfo.nodeRootBlockHeight).isEqualTo(0)
         assertThat(nodeVersionInfo.compatibleRange).isEqualTo(null)
     }
+
 
     @Test
     fun `Can get transaction results`() {
@@ -211,7 +190,7 @@ class TransactionIntegrationTest {
         val address = serviceAccount.flowAddress
 
         val balanceResponse = safelyHandle(
-            { handleResult(accessAPI.getAccountBalanceAtLatestBlock(address), "Failed to get account balance at latest block") },
+            { Result.success(handleResult(accessAPI.getAccountBalanceAtLatestBlock(address), "Failed to get account balance at latest block")) },
             "Failed to retrieve account balance at latest block"
         )
 
@@ -227,7 +206,7 @@ class TransactionIntegrationTest {
         val balanceResponse = getAccountBalanceAtBlockHeight(serviceAccount.flowAddress, latestBlock.height)
 
         val account = safelyHandle(
-            { handleResult(accessAPI.getAccountByBlockHeight(serviceAccount.flowAddress, latestBlock.height), "Failed to get account by block height") },
+            { Result.success(handleResult(accessAPI.getAccountByBlockHeight(serviceAccount.flowAddress, latestBlock.height), "Failed to get account by block height")) },
             "Failed to retrieve account by block height"
         )
 
@@ -238,7 +217,7 @@ class TransactionIntegrationTest {
     @Test
     fun `Can get latest block`() {
         val latestBlock = safelyHandle(
-            { handleResult(accessAPI.getLatestBlock(true), "Failed to get latest block") },
+            { Result.success(handleResult(accessAPI.getLatestBlock(true), "Failed to get latest block")) },
             "Failed to retrieve latest block"
         )
 
@@ -250,7 +229,7 @@ class TransactionIntegrationTest {
         val latestBlock = getLatestBlock()
 
         val blockById = safelyHandle(
-            { handleResult(accessAPI.getBlockById(latestBlock.id), "Failed to get block by ID") },
+            { Result.success(handleResult(accessAPI.getBlockById(latestBlock.id), "Failed to get block by ID")) },
             "Failed to retrieve block by ID"
         )
 
@@ -262,7 +241,7 @@ class TransactionIntegrationTest {
     fun `Can get block by height`() {
         val latestBlock = getLatestBlock()
         val blockByHeight = safelyHandle(
-            { handleResult(accessAPI.getBlockByHeight(latestBlock.height), "Failed to get block by height") },
+            { Result.success(handleResult(accessAPI.getBlockByHeight(latestBlock.height), "Failed to get block by height")) },
             "Failed to retrieve block by height"
         )
 
@@ -274,7 +253,7 @@ class TransactionIntegrationTest {
     fun `Can get account by address`() {
         val address = serviceAccount.flowAddress
         val account = safelyHandle(
-            { handleResult(accessAPI.getAccountByAddress(address), "Failed to get account by address") },
+            { Result.success(handleResult(accessAPI.getAccountByAddress(address), "Failed to get account by address")) },
             "Failed to retrieve account by address"
         )
 
@@ -286,7 +265,7 @@ class TransactionIntegrationTest {
     fun `Can get account by address at latest block`() {
         val address = serviceAccount.flowAddress
         val account = safelyHandle(
-            { handleResult(accessAPI.getAccountAtLatestBlock(address), "Failed to get account at latest block") },
+            { Result.success(handleResult(accessAPI.getAccountAtLatestBlock(address), "Failed to get account at latest block")) },
             "Failed to retrieve account at latest block"
         )
 
@@ -298,7 +277,7 @@ class TransactionIntegrationTest {
     fun `Can get account by block height`() {
         val latestBlock = getLatestBlock()
         val account = safelyHandle(
-            { handleResult(accessAPI.getAccountByBlockHeight(serviceAccount.flowAddress, latestBlock.height), "Failed to get account by block height") },
+            { Result.success(handleResult(accessAPI.getAccountByBlockHeight(serviceAccount.flowAddress, latestBlock.height), "Failed to get account by block height")) },
             "Failed to retrieve account by block height"
         )
 

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -33,6 +33,9 @@ class TransactionIntegrationTest {
         const val BLOCK_HEIGHT_ERROR = "Failed to get block by height"
         const val ACCOUNT_BY_ADDRESS_ERROR = "Failed to get account by address"
         const val ACCOUNT_BY_BLOCK_HEIGHT_ERROR = "Failed to get account by block height"
+        const val PROTOCOL_STATE_HEIGHT_ERROR = "Failed to get protocol state snapshot by height"
+        const val PROTOCOL_STATE_BLOCK_ERROR = "Failed to get protocol state snapshot by block ID"
+        const val PROTOCOL_STATE_LATEST_ERROR = "Failed to get latest protocol state snapshot"
     }
 
     private fun <T> safelyHandle(action: () -> Result<T>, errorMessage: String): T =
@@ -84,6 +87,35 @@ class TransactionIntegrationTest {
         val account = getAccountAtLatestBlock(serviceAccount.flowAddress)
         assertThat(account).isNotNull
         assertThat(account.keys).isNotEmpty()
+    }
+
+    @Test
+    fun `Can get latest protocol state snapshot`() {
+        val snapshot = safelyHandle(
+            { Result.success(handleResult(accessAPI.getLatestProtocolStateSnapshot(), PROTOCOL_STATE_LATEST_ERROR)) },
+            PROTOCOL_STATE_LATEST_ERROR
+        )
+        assertThat(snapshot).isNotNull
+    }
+
+    @Test
+    fun `Can get protocol state snapshot by blockId`() {
+        val latestBlock = getLatestBlock()
+        val snapshot = safelyHandle(
+            { Result.success(handleResult(accessAPI.getProtocolStateSnapshotByBlockId(latestBlock.id), PROTOCOL_STATE_HEIGHT_ERROR)) },
+            PROTOCOL_STATE_BLOCK_ERROR
+        )
+        assertThat(snapshot).isNotNull
+    }
+
+    @Test
+    fun `Can get protocol state snapshot by height`() {
+        val latestBlock = getLatestBlock()
+        val snapshot = safelyHandle(
+            { Result.success(handleResult(accessAPI.getProtocolStateSnapshotByHeight(latestBlock.height), PROTOCOL_STATE_HEIGHT_ERROR)) },
+            PROTOCOL_STATE_HEIGHT_ERROR
+        )
+        assertThat(snapshot).isNotNull
     }
 
     @Test

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -106,7 +106,7 @@ class TransactionIntegrationTest {
         )
 
         assertThat(accountKey).isNotNull
-        assertThat(accountKey!!.sequenceNumber).isEqualTo(0)
+        assertThat(accountKey.sequenceNumber).isEqualTo(0)
     }
 
     @Test

--- a/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
+++ b/sdk/src/intTest/org/onflow/flow/sdk/transaction/TransactionIntegrationTest.kt
@@ -29,7 +29,6 @@ class TransactionIntegrationTest {
         const val TRANSACTION_RESULT_ERROR = "Failed to get transaction result"
         const val NODE_VERSION_INFO_ERROR = "Failed to get node version info"
         const val ACCOUNT_BALANCE_LATEST_ERROR = "Failed to get account balance at latest block"
-        const val ACCOUNT_BALANCE_BLOCK_HEIGHT_ERROR = "Failed to get account balance at block height"
         const val BLOCK_ID_ERROR = "Failed to get block by ID"
         const val BLOCK_HEIGHT_ERROR = "Failed to get block by height"
         const val ACCOUNT_BY_ADDRESS_ERROR = "Failed to get account by address"
@@ -132,8 +131,8 @@ class TransactionIntegrationTest {
         val latestBlock = getLatestBlock()
 
         val accountKeys = safelyHandle(
-            { Result.success(handleResult(accessAPI.getAccountKeysAtBlockHeight(address, latestBlock.height), "Failed to get account keys at block height")) },
-            "Failed to retrieve account keys at block height"
+            { Result.success(handleResult(accessAPI.getAccountKeysAtBlockHeight(address, latestBlock.height), ACCOUNT_KEYS_ERROR)) },
+            ACCOUNT_KEYS_ERROR
         )
 
         assertThat(accountKeys).isNotNull
@@ -143,8 +142,8 @@ class TransactionIntegrationTest {
     @Test
     fun `Can get node version info`() {
         val nodeVersionInfo = safelyHandle(
-            { Result.success(handleResult(accessAPI.getNodeVersionInfo(), "Failed to get node version info")) },
-            "Failed to retrieve node version info"
+            { Result.success(handleResult(accessAPI.getNodeVersionInfo(), NODE_VERSION_INFO_ERROR)) },
+            NODE_VERSION_INFO_ERROR
         )
 
         assertThat(nodeVersionInfo).isNotNull
@@ -153,7 +152,6 @@ class TransactionIntegrationTest {
         assertThat(nodeVersionInfo.nodeRootBlockHeight).isEqualTo(0)
         assertThat(nodeVersionInfo.compatibleRange).isEqualTo(null)
     }
-
 
     @Test
     fun `Can get transaction results`() {
@@ -243,10 +241,7 @@ class TransactionIntegrationTest {
 
     @Test
     fun `Can get latest block`() {
-        val latestBlock = safelyHandle(
-            { Result.success(handleResult(accessAPI.getLatestBlock(true), LATEST_BLOCK_ERROR)) },
-            LATEST_BLOCK_ERROR
-        )
+        val latestBlock = getLatestBlock()
 
         assertThat(latestBlock).isNotNull
     }
@@ -291,10 +286,7 @@ class TransactionIntegrationTest {
     @Test
     fun `Can get account by address at latest block`() {
         val address = serviceAccount.flowAddress
-        val account = safelyHandle(
-            { Result.success(handleResult(accessAPI.getAccountAtLatestBlock(address), ACCOUNT_AT_LATEST_BLOCK_ERROR)) },
-            ACCOUNT_AT_LATEST_BLOCK_ERROR
-        )
+        val account = getAccountAtLatestBlock(address)
 
         assertThat(account).isNotNull
         assertThat(account.address).isEqualTo(address)

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
@@ -32,6 +32,8 @@ interface AsyncFlowAccessApi {
 
     fun getCollectionById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowCollection?>>
 
+    fun getFullCollectionById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowTransaction>>>
+
     fun sendTransaction(transaction: FlowTransaction): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowId>>
 
     fun getTransactionById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransaction?>>

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/AsyncFlowAccessApi.kt
@@ -64,6 +64,10 @@ interface AsyncFlowAccessApi {
 
     fun getLatestProtocolStateSnapshot(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowSnapshot>>
 
+    fun getProtocolStateSnapshotByBlockId(blockId: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowSnapshot>>
+
+    fun getProtocolStateSnapshotByHeight(height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowSnapshot>>
+
     fun getNodeVersionInfo(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowNodeVersionInfo>>
 
     fun getTransactionsByBlockId(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowTransaction>>>

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
@@ -44,6 +44,8 @@ interface FlowAccessApi {
 
     fun getCollectionById(id: FlowId): AccessApiCallResponse<FlowCollection>
 
+    fun getFullCollectionById(id: FlowId): AccessApiCallResponse<List<FlowTransaction>>
+
     fun sendTransaction(transaction: FlowTransaction): AccessApiCallResponse<FlowId>
 
     fun getTransactionById(id: FlowId): AccessApiCallResponse<FlowTransaction>

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/FlowAccessApi.kt
@@ -76,6 +76,10 @@ interface FlowAccessApi {
 
     fun getLatestProtocolStateSnapshot(): AccessApiCallResponse<FlowSnapshot>
 
+    fun getProtocolStateSnapshotByBlockId(blockId: FlowId): AccessApiCallResponse<FlowSnapshot>
+
+    fun getProtocolStateSnapshotByHeight(height: Long): AccessApiCallResponse<FlowSnapshot>
+
     fun getNodeVersionInfo(): AccessApiCallResponse<FlowNodeVersionInfo>
 
     fun getTransactionsByBlockId(id: FlowId): AccessApiCallResponse<List<FlowTransaction>>

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -285,6 +285,20 @@ class AsyncFlowAccessApiImpl(
             errorMessage = "Failed to get collection by ID"
         )
 
+    override fun getFullCollectionById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowTransaction>>> =
+        handleApiCall(
+            apiCall = {
+                api.getFullCollectionByID(
+                    Access.GetFullCollectionByIDRequest
+                        .newBuilder()
+                        .setId(id.byteStringValue)
+                        .build()
+                )
+            },
+            transform = { fullCollectionResponse -> fullCollectionResponse.transactionsList.map { FlowTransaction.of(it) } },
+            errorMessage = "Failed to get full collection by ID"
+        )
+
     override fun sendTransaction(transaction: FlowTransaction): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowId>> =
         handleApiCall(
             apiCall = {

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -452,6 +452,20 @@ class AsyncFlowAccessApiImpl(
             errorMessage = "Failed to get latest protocol state snapshot"
         )
 
+    override fun getProtocolStateSnapshotByHeight(height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowSnapshot>> =
+        handleApiCall(
+            apiCall = { api.getProtocolStateSnapshotByHeight(Access.GetProtocolStateSnapshotByHeightRequest.newBuilder().setBlockHeight(height).build()) },
+            transform = { FlowSnapshot(it.serializedSnapshot.toByteArray()) },
+            errorMessage = "Failed to get protocol state snapshot by height"
+        )
+
+    override fun getProtocolStateSnapshotByBlockId(blockId: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowSnapshot>> =
+        handleApiCall(
+            apiCall = { api.getProtocolStateSnapshotByBlockID(Access.GetProtocolStateSnapshotByBlockIDRequest.newBuilder().setBlockId(blockId.byteStringValue).build()) },
+            transform = { FlowSnapshot(it.serializedSnapshot.toByteArray()) },
+            errorMessage = "Failed to get protocol state snapshot by block ID"
+        )
+
     override fun getNodeVersionInfo(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowNodeVersionInfo>> =
         handleApiCall(
             apiCall = { api.getNodeVersionInfo(Access.GetNodeVersionInfoRequest.newBuilder().build()) },

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -33,7 +33,11 @@ class AsyncFlowAccessApiImpl(
                 if (ex != null) {
                     FlowAccessApi.AccessApiCallResponse.Error(errorMessage, ex)
                 } else {
-                    FlowAccessApi.AccessApiCallResponse.Success(transform(response))
+                    try {
+                        FlowAccessApi.AccessApiCallResponse.Success(transform(response))
+                    } catch (e: Exception) {
+                        FlowAccessApi.AccessApiCallResponse.Error(errorMessage, e)
+                    }
                 }
             }
         } catch (e: Exception) {

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -47,18 +47,18 @@ class AsyncFlowAccessApiImpl(
     override fun ping(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<Unit>> =
         handleApiCall(
             apiCall = { api.ping(Access.PingRequest.newBuilder().build()) },
-            transform = { Unit },
+            transform = { },
             errorMessage = "Failed to ping"
         )
 
     @Deprecated("Behaves identically to getAccountAtLatestBlock", replaceWith = ReplaceWith("getAccountAtLatestBlock"))
-    override fun getAccountByAddress(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> =
+    override fun getAccountByAddress(addresss: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> =
         handleApiCall(
             apiCall = {
                 api.getAccount(
                     Access.GetAccountRequest
                         .newBuilder()
-                        .setAddress(address.byteStringValue)
+                        .setAddress(addresss.byteStringValue)
                         .build()
                 )
             },
@@ -66,13 +66,13 @@ class AsyncFlowAccessApiImpl(
             errorMessage = "Failed to get account by address"
         )
 
-    override fun getAccountAtLatestBlock(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> =
+    override fun getAccountAtLatestBlock(addresss: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> =
         handleApiCall(
             apiCall = {
                 api.getAccountAtLatestBlock(
                     Access.GetAccountAtLatestBlockRequest
                         .newBuilder()
-                        .setAddress(address.byteStringValue)
+                        .setAddress(addresss.byteStringValue)
                         .build()
                 )
             },
@@ -80,13 +80,13 @@ class AsyncFlowAccessApiImpl(
             errorMessage = "Failed to get account at latest block"
         )
 
-    override fun getAccountByBlockHeight(address: FlowAddress, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> =
+    override fun getAccountByBlockHeight(addresss: FlowAddress, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> =
         handleApiCall(
             apiCall = {
                 api.getAccountAtBlockHeight(
                     Access.GetAccountAtBlockHeightRequest
                         .newBuilder()
-                        .setAddress(address.byteStringValue)
+                        .setAddress(addresss.byteStringValue)
                         .setBlockHeight(height)
                         .build()
                 )
@@ -353,12 +353,14 @@ class AsyncFlowAccessApiImpl(
         )
 
     override fun executeScriptAtLatestBlock(
-        script: FlowScript, arguments: Iterable<ByteString>
+        script: FlowScript,
+        arguments: Iterable<ByteString>
     ): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
         executeScript(
             apiCall = {
                 api.executeScriptAtLatestBlock(
-                    Access.ExecuteScriptAtLatestBlockRequest.newBuilder()
+                    Access.ExecuteScriptAtLatestBlockRequest
+                        .newBuilder()
                         .setScript(script.byteStringValue)
                         .addAllArguments(arguments)
                         .build()
@@ -368,12 +370,15 @@ class AsyncFlowAccessApiImpl(
         )
 
     override fun executeScriptAtBlockId(
-        script: FlowScript, blockId: FlowId, arguments: Iterable<ByteString>
+        script: FlowScript,
+        blockId: FlowId,
+        arguments: Iterable<ByteString>
     ): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
         executeScript(
             apiCall = {
                 api.executeScriptAtBlockID(
-                    Access.ExecuteScriptAtBlockIDRequest.newBuilder()
+                    Access.ExecuteScriptAtBlockIDRequest
+                        .newBuilder()
                         .setBlockId(blockId.byteStringValue)
                         .setScript(script.byteStringValue)
                         .addAllArguments(arguments)
@@ -384,12 +389,15 @@ class AsyncFlowAccessApiImpl(
         )
 
     override fun executeScriptAtBlockHeight(
-        script: FlowScript, height: Long, arguments: Iterable<ByteString>
+        script: FlowScript,
+        height: Long,
+        arguments: Iterable<ByteString>
     ): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
         executeScript(
             apiCall = {
                 api.executeScriptAtBlockHeight(
-                    Access.ExecuteScriptAtBlockHeightRequest.newBuilder()
+                    Access.ExecuteScriptAtBlockHeightRequest
+                        .newBuilder()
                         .setBlockHeight(height)
                         .setScript(script.byteStringValue)
                         .addAllArguments(arguments)
@@ -399,8 +407,7 @@ class AsyncFlowAccessApiImpl(
             errorMessage = "Failed to execute script at block height"
         )
 
-
-     override fun getEventsForHeightRange(type: String, range: ClosedRange<Long>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowEventResult>>> =
+    override fun getEventsForHeightRange(type: String, range: ClosedRange<Long>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowEventResult>>> =
         handleApiCall(
             apiCall = {
                 api.getEventsForHeightRange(

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -27,8 +27,8 @@ class AsyncFlowAccessApiImpl(
         apiCall: () -> ListenableFuture<T>,
         transform: (T) -> R,
         errorMessage: String
-    ): CompletableFuture<FlowAccessApi.AccessApiCallResponse<R>> {
-        return try {
+    ): CompletableFuture<FlowAccessApi.AccessApiCallResponse<R>> =
+        try {
             completableFuture(apiCall()).handle { response, ex ->
                 if (ex != null) {
                     FlowAccessApi.AccessApiCallResponse.Error(errorMessage, ex)
@@ -39,22 +39,21 @@ class AsyncFlowAccessApiImpl(
         } catch (e: Exception) {
             CompletableFuture.completedFuture(FlowAccessApi.AccessApiCallResponse.Error(errorMessage, e))
         }
-    }
 
-    override fun ping(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<Unit>> {
-        return handleApiCall(
+    override fun ping(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<Unit>> =
+        handleApiCall(
             apiCall = { api.ping(Access.PingRequest.newBuilder().build()) },
             transform = { Unit },
             errorMessage = "Failed to ping"
         )
-    }
 
     @Deprecated("Behaves identically to getAccountAtLatestBlock", replaceWith = ReplaceWith("getAccountAtLatestBlock"))
-    override fun getAccountByAddress(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> {
-        return handleApiCall(
+    override fun getAccountByAddress(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> =
+        handleApiCall(
             apiCall = {
                 api.getAccount(
-                    Access.GetAccountRequest.newBuilder()
+                    Access.GetAccountRequest
+                        .newBuilder()
                         .setAddress(address.byteStringValue)
                         .build()
                 )
@@ -62,13 +61,13 @@ class AsyncFlowAccessApiImpl(
             transform = { if (it.hasAccount()) FlowAccount.of(it.account) else throw IllegalStateException("Account not found") },
             errorMessage = "Failed to get account by address"
         )
-    }
 
-    override fun getAccountAtLatestBlock(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> {
-        return handleApiCall(
+    override fun getAccountAtLatestBlock(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> =
+        handleApiCall(
             apiCall = {
                 api.getAccountAtLatestBlock(
-                    Access.GetAccountAtLatestBlockRequest.newBuilder()
+                    Access.GetAccountAtLatestBlockRequest
+                        .newBuilder()
                         .setAddress(address.byteStringValue)
                         .build()
                 )
@@ -76,13 +75,13 @@ class AsyncFlowAccessApiImpl(
             transform = { if (it.hasAccount()) FlowAccount.of(it.account) else throw IllegalStateException("Account not found") },
             errorMessage = "Failed to get account at latest block"
         )
-    }
 
-    override fun getAccountByBlockHeight(address: FlowAddress, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> {
-        return handleApiCall(
+    override fun getAccountByBlockHeight(address: FlowAddress, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccount>> =
+        handleApiCall(
             apiCall = {
                 api.getAccountAtBlockHeight(
-                    Access.GetAccountAtBlockHeightRequest.newBuilder()
+                    Access.GetAccountAtBlockHeightRequest
+                        .newBuilder()
                         .setAddress(address.byteStringValue)
                         .setBlockHeight(height)
                         .build()
@@ -91,13 +90,13 @@ class AsyncFlowAccessApiImpl(
             transform = { if (it.hasAccount()) FlowAccount.of(it.account) else throw IllegalStateException("Account not found") },
             errorMessage = "Failed to get account by block height"
         )
-    }
 
-    override fun getAccountKeyAtLatestBlock(address: FlowAddress, keyIndex: Int): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccountKey>> {
-        return handleApiCall(
+    override fun getAccountKeyAtLatestBlock(address: FlowAddress, keyIndex: Int): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccountKey>> =
+        handleApiCall(
             apiCall = {
                 api.getAccountKeyAtLatestBlock(
-                    Access.GetAccountKeyAtLatestBlockRequest.newBuilder()
+                    Access.GetAccountKeyAtLatestBlockRequest
+                        .newBuilder()
                         .setAddress(address.byteStringValue)
                         .setIndex(keyIndex)
                         .build()
@@ -106,13 +105,13 @@ class AsyncFlowAccessApiImpl(
             transform = { FlowAccountKey.of(it.accountKey) },
             errorMessage = "Failed to get account key at latest block"
         )
-    }
 
-    override fun getAccountKeyAtBlockHeight(address: FlowAddress, keyIndex: Int, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccountKey>> {
-        return handleApiCall(
+    override fun getAccountKeyAtBlockHeight(address: FlowAddress, keyIndex: Int, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowAccountKey>> =
+        handleApiCall(
             apiCall = {
                 api.getAccountKeyAtBlockHeight(
-                    Access.GetAccountKeyAtBlockHeightRequest.newBuilder()
+                    Access.GetAccountKeyAtBlockHeightRequest
+                        .newBuilder()
                         .setAddress(address.byteStringValue)
                         .setIndex(keyIndex)
                         .setBlockHeight(height)
@@ -122,13 +121,13 @@ class AsyncFlowAccessApiImpl(
             transform = { FlowAccountKey.of(it.accountKey) },
             errorMessage = "Failed to get account key at block height"
         )
-    }
 
-    override fun getAccountKeysAtLatestBlock(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>>> {
-        return handleApiCall(
+    override fun getAccountKeysAtLatestBlock(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>>> =
+        handleApiCall(
             apiCall = {
                 api.getAccountKeysAtLatestBlock(
-                    Access.GetAccountKeysAtLatestBlockRequest.newBuilder()
+                    Access.GetAccountKeysAtLatestBlockRequest
+                        .newBuilder()
                         .setAddress(address.byteStringValue)
                         .build()
                 )
@@ -136,13 +135,13 @@ class AsyncFlowAccessApiImpl(
             transform = { it.accountKeysList.map { FlowAccountKey.of(it) } },
             errorMessage = "Failed to get account keys at latest block"
         )
-    }
 
-    override fun getAccountKeysAtBlockHeight(address: FlowAddress, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>>> {
-        return handleApiCall(
+    override fun getAccountKeysAtBlockHeight(address: FlowAddress, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>>> =
+        handleApiCall(
             apiCall = {
                 api.getAccountKeysAtBlockHeight(
-                    Access.GetAccountKeysAtBlockHeightRequest.newBuilder()
+                    Access.GetAccountKeysAtBlockHeightRequest
+                        .newBuilder()
                         .setAddress(address.byteStringValue)
                         .setBlockHeight(height)
                         .build()
@@ -151,13 +150,13 @@ class AsyncFlowAccessApiImpl(
             transform = { it.accountKeysList.map { FlowAccountKey.of(it) } },
             errorMessage = "Failed to get account keys at block height"
         )
-    }
 
-    override fun getLatestBlockHeader(sealed: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlockHeader>> {
-        return handleApiCall(
+    override fun getLatestBlockHeader(sealed: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlockHeader>> =
+        handleApiCall(
             apiCall = {
                 api.getLatestBlockHeader(
-                    Access.GetLatestBlockHeaderRequest.newBuilder()
+                    Access.GetLatestBlockHeaderRequest
+                        .newBuilder()
                         .setIsSealed(sealed)
                         .build()
                 )
@@ -165,13 +164,13 @@ class AsyncFlowAccessApiImpl(
             transform = { FlowBlockHeader.of(it.block) },
             errorMessage = "Failed to get latest block header"
         )
-    }
 
-    override fun getBlockHeaderById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlockHeader?>> {
-        return handleApiCall(
+    override fun getBlockHeaderById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlockHeader?>> =
+        handleApiCall(
             apiCall = {
                 api.getBlockHeaderByID(
-                    Access.GetBlockHeaderByIDRequest.newBuilder()
+                    Access.GetBlockHeaderByIDRequest
+                        .newBuilder()
                         .setId(id.byteStringValue)
                         .build()
                 )
@@ -179,13 +178,13 @@ class AsyncFlowAccessApiImpl(
             transform = { if (it.hasBlock()) FlowBlockHeader.of(it.block) else null },
             errorMessage = "Failed to get block header by ID"
         )
-    }
 
-    override fun getBlockHeaderByHeight(height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlockHeader?>> {
-        return handleApiCall(
+    override fun getBlockHeaderByHeight(height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlockHeader?>> =
+        handleApiCall(
             apiCall = {
                 api.getBlockHeaderByHeight(
-                    Access.GetBlockHeaderByHeightRequest.newBuilder()
+                    Access.GetBlockHeaderByHeightRequest
+                        .newBuilder()
                         .setHeight(height)
                         .build()
                 )
@@ -193,13 +192,13 @@ class AsyncFlowAccessApiImpl(
             transform = { if (it.hasBlock()) FlowBlockHeader.of(it.block) else null },
             errorMessage = "Failed to get block header by height"
         )
-    }
 
-    override fun getLatestBlock(sealed: Boolean, fullBlockResponse: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock>> {
-        return handleApiCall(
+    override fun getLatestBlock(sealed: Boolean, fullBlockResponse: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock>> =
+        handleApiCall(
             apiCall = {
                 api.getLatestBlock(
-                    Access.GetLatestBlockRequest.newBuilder()
+                    Access.GetLatestBlockRequest
+                        .newBuilder()
                         .setIsSealed(sealed)
                         .setFullBlockResponse(fullBlockResponse)
                         .build()
@@ -208,13 +207,13 @@ class AsyncFlowAccessApiImpl(
             transform = { FlowBlock.of(it.block) },
             errorMessage = "Failed to get latest block"
         )
-    }
 
-    override fun getAccountBalanceAtLatestBlock(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<Long>> {
-        return handleApiCall(
+    override fun getAccountBalanceAtLatestBlock(address: FlowAddress): CompletableFuture<FlowAccessApi.AccessApiCallResponse<Long>> =
+        handleApiCall(
             apiCall = {
                 api.getAccountBalanceAtLatestBlock(
-                    Access.GetAccountBalanceAtLatestBlockRequest.newBuilder()
+                    Access.GetAccountBalanceAtLatestBlockRequest
+                        .newBuilder()
                         .setAddress(address.byteStringValue)
                         .build()
                 )
@@ -222,13 +221,13 @@ class AsyncFlowAccessApiImpl(
             transform = { it.balance },
             errorMessage = "Failed to get account balance at latest block"
         )
-    }
 
-    override fun getAccountBalanceAtBlockHeight(address: FlowAddress, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<Long>> {
-        return handleApiCall(
+    override fun getAccountBalanceAtBlockHeight(address: FlowAddress, height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<Long>> =
+        handleApiCall(
             apiCall = {
                 api.getAccountBalanceAtBlockHeight(
-                    Access.GetAccountBalanceAtBlockHeightRequest.newBuilder()
+                    Access.GetAccountBalanceAtBlockHeightRequest
+                        .newBuilder()
                         .setAddress(address.byteStringValue)
                         .setBlockHeight(height)
                         .build()
@@ -237,13 +236,13 @@ class AsyncFlowAccessApiImpl(
             transform = { it.balance },
             errorMessage = "Failed to get account balance at block height"
         )
-    }
 
-    override fun getBlockById(id: FlowId, fullBlockResponse: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>> {
-        return handleApiCall(
+    override fun getBlockById(id: FlowId, fullBlockResponse: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>> =
+        handleApiCall(
             apiCall = {
                 api.getBlockByID(
-                    Access.GetBlockByIDRequest.newBuilder()
+                    Access.GetBlockByIDRequest
+                        .newBuilder()
                         .setId(id.byteStringValue)
                         .setFullBlockResponse(fullBlockResponse)
                         .build()
@@ -252,13 +251,13 @@ class AsyncFlowAccessApiImpl(
             transform = { if (it.hasBlock()) FlowBlock.of(it.block) else null },
             errorMessage = "Failed to get block by ID"
         )
-    }
 
-    override fun getBlockByHeight(height: Long, fullBlockResponse: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>> {
-        return handleApiCall(
+    override fun getBlockByHeight(height: Long, fullBlockResponse: Boolean): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowBlock?>> =
+        handleApiCall(
             apiCall = {
                 api.getBlockByHeight(
-                    Access.GetBlockByHeightRequest.newBuilder()
+                    Access.GetBlockByHeightRequest
+                        .newBuilder()
                         .setHeight(height)
                         .setFullBlockResponse(fullBlockResponse)
                         .build()
@@ -267,13 +266,13 @@ class AsyncFlowAccessApiImpl(
             transform = { if (it.hasBlock()) FlowBlock.of(it.block) else null },
             errorMessage = "Failed to get block by height"
         )
-    }
 
-    override fun getCollectionById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowCollection?>> {
-        return handleApiCall(
+    override fun getCollectionById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowCollection?>> =
+        handleApiCall(
             apiCall = {
                 api.getCollectionByID(
-                    Access.GetCollectionByIDRequest.newBuilder()
+                    Access.GetCollectionByIDRequest
+                        .newBuilder()
                         .setId(id.byteStringValue)
                         .build()
                 )
@@ -281,13 +280,13 @@ class AsyncFlowAccessApiImpl(
             transform = { if (it.hasCollection()) FlowCollection.of(it.collection) else null },
             errorMessage = "Failed to get collection by ID"
         )
-    }
 
-    override fun sendTransaction(transaction: FlowTransaction): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowId>> {
-        return handleApiCall(
+    override fun sendTransaction(transaction: FlowTransaction): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowId>> =
+        handleApiCall(
             apiCall = {
                 api.sendTransaction(
-                    Access.SendTransactionRequest.newBuilder()
+                    Access.SendTransactionRequest
+                        .newBuilder()
                         .setTransaction(transaction.builder().build())
                         .build()
                 )
@@ -295,13 +294,13 @@ class AsyncFlowAccessApiImpl(
             transform = { FlowId.of(it.id.toByteArray()) },
             errorMessage = "Failed to send transaction"
         )
-    }
 
-    override fun getTransactionById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransaction?>> {
-        return handleApiCall(
+    override fun getTransactionById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransaction?>> =
+        handleApiCall(
             apiCall = {
                 api.getTransaction(
-                    Access.GetTransactionRequest.newBuilder()
+                    Access.GetTransactionRequest
+                        .newBuilder()
                         .setId(id.byteStringValue)
                         .build()
                 )
@@ -309,13 +308,13 @@ class AsyncFlowAccessApiImpl(
             transform = { if (it.hasTransaction()) FlowTransaction.of(it.transaction) else null },
             errorMessage = "Failed to get transaction by ID"
         )
-    }
 
-    override fun getTransactionResultById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult?>> {
-        return handleApiCall(
+    override fun getTransactionResultById(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult?>> =
+        handleApiCall(
             apiCall = {
                 api.getTransactionResult(
-                    Access.GetTransactionRequest.newBuilder()
+                    Access.GetTransactionRequest
+                        .newBuilder()
                         .setId(id.byteStringValue)
                         .build()
                 )
@@ -323,13 +322,13 @@ class AsyncFlowAccessApiImpl(
             transform = { FlowTransactionResult.of(it) },
             errorMessage = "Failed to get transaction result by ID"
         )
-    }
 
-    override fun getTransactionResultByIndex(blockId: FlowId, index: Int): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>> {
-        return handleApiCall(
+    override fun getTransactionResultByIndex(blockId: FlowId, index: Int): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowTransactionResult>> =
+        handleApiCall(
             apiCall = {
                 api.getTransactionResultByIndex(
-                    Access.GetTransactionByIndexRequest.newBuilder()
+                    Access.GetTransactionByIndexRequest
+                        .newBuilder()
                         .setBlockId(blockId.byteStringValue)
                         .setIndex(index)
                         .build()
@@ -338,13 +337,13 @@ class AsyncFlowAccessApiImpl(
             transform = { FlowTransactionResult.of(it) },
             errorMessage = "Failed to get transaction result by index"
         )
-    }
 
-    override fun executeScriptAtLatestBlock(script: FlowScript, arguments: Iterable<ByteString>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> {
-        return handleApiCall(
+    override fun executeScriptAtLatestBlock(script: FlowScript, arguments: Iterable<ByteString>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
+        handleApiCall(
             apiCall = {
                 api.executeScriptAtLatestBlock(
-                    Access.ExecuteScriptAtLatestBlockRequest.newBuilder()
+                    Access.ExecuteScriptAtLatestBlockRequest
+                        .newBuilder()
                         .setScript(script.byteStringValue)
                         .addAllArguments(arguments)
                         .build()
@@ -353,13 +352,13 @@ class AsyncFlowAccessApiImpl(
             transform = { FlowScriptResponse(it.value.toByteArray()) },
             errorMessage = "Failed to execute script at latest block"
         )
-    }
 
-    override fun executeScriptAtBlockId(script: FlowScript, blockId: FlowId, arguments: Iterable<ByteString>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> {
-        return handleApiCall(
+    override fun executeScriptAtBlockId(script: FlowScript, blockId: FlowId, arguments: Iterable<ByteString>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
+        handleApiCall(
             apiCall = {
                 api.executeScriptAtBlockID(
-                    Access.ExecuteScriptAtBlockIDRequest.newBuilder()
+                    Access.ExecuteScriptAtBlockIDRequest
+                        .newBuilder()
                         .setBlockId(blockId.byteStringValue)
                         .setScript(script.byteStringValue)
                         .addAllArguments(arguments)
@@ -369,13 +368,13 @@ class AsyncFlowAccessApiImpl(
             transform = { FlowScriptResponse(it.value.toByteArray()) },
             errorMessage = "Failed to execute script at block ID"
         )
-    }
 
-    override fun executeScriptAtBlockHeight(script: FlowScript, height: Long, arguments: Iterable<ByteString>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> {
-        return handleApiCall(
+    override fun executeScriptAtBlockHeight(script: FlowScript, height: Long, arguments: Iterable<ByteString>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
+        handleApiCall(
             apiCall = {
                 api.executeScriptAtBlockHeight(
-                    Access.ExecuteScriptAtBlockHeightRequest.newBuilder()
+                    Access.ExecuteScriptAtBlockHeightRequest
+                        .newBuilder()
                         .setBlockHeight(height)
                         .setScript(script.byteStringValue)
                         .addAllArguments(arguments)
@@ -385,13 +384,13 @@ class AsyncFlowAccessApiImpl(
             transform = { FlowScriptResponse(it.value.toByteArray()) },
             errorMessage = "Failed to execute script at block height"
         )
-    }
 
-    override fun getEventsForHeightRange(type: String, range: ClosedRange<Long>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowEventResult>>> {
-        return handleApiCall(
+    override fun getEventsForHeightRange(type: String, range: ClosedRange<Long>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowEventResult>>> =
+        handleApiCall(
             apiCall = {
                 api.getEventsForHeightRange(
-                    Access.GetEventsForHeightRangeRequest.newBuilder()
+                    Access.GetEventsForHeightRangeRequest
+                        .newBuilder()
                         .setType(type)
                         .setStartHeight(range.start)
                         .setEndHeight(range.endInclusive)
@@ -401,13 +400,13 @@ class AsyncFlowAccessApiImpl(
             transform = { it.resultsList.map { FlowEventResult.of(it) } },
             errorMessage = "Failed to get events for height range"
         )
-    }
 
-    override fun getEventsForBlockIds(type: String, ids: Set<FlowId>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowEventResult>>> {
-        return handleApiCall(
+    override fun getEventsForBlockIds(type: String, ids: Set<FlowId>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowEventResult>>> =
+        handleApiCall(
             apiCall = {
                 api.getEventsForBlockIDs(
-                    Access.GetEventsForBlockIDsRequest.newBuilder()
+                    Access.GetEventsForBlockIDsRequest
+                        .newBuilder()
                         .setType(type)
                         .addAllBlockIds(ids.map { it.byteStringValue })
                         .build()
@@ -416,42 +415,39 @@ class AsyncFlowAccessApiImpl(
             transform = { it.resultsList.map { FlowEventResult.of(it) } },
             errorMessage = "Failed to get events for block IDs"
         )
-    }
 
-    override fun getNetworkParameters(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowChainId>> {
-        return handleApiCall(
+    override fun getNetworkParameters(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowChainId>> =
+        handleApiCall(
             apiCall = { api.getNetworkParameters(Access.GetNetworkParametersRequest.newBuilder().build()) },
             transform = { FlowChainId.of(it.chainId) },
             errorMessage = "Failed to get network parameters"
         )
-    }
 
-    override fun getLatestProtocolStateSnapshot(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowSnapshot>> {
-        return handleApiCall(
+    override fun getLatestProtocolStateSnapshot(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowSnapshot>> =
+        handleApiCall(
             apiCall = { api.getLatestProtocolStateSnapshot(Access.GetLatestProtocolStateSnapshotRequest.newBuilder().build()) },
             transform = { FlowSnapshot(it.serializedSnapshot.toByteArray()) },
             errorMessage = "Failed to get latest protocol state snapshot"
         )
-    }
 
-    override fun getNodeVersionInfo(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowNodeVersionInfo>> {
-        return handleApiCall(
+    override fun getNodeVersionInfo(): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowNodeVersionInfo>> =
+        handleApiCall(
             apiCall = { api.getNodeVersionInfo(Access.GetNodeVersionInfoRequest.newBuilder().build()) },
             transform = { response ->
                 val compatibleRange = if (response.info.hasCompatibleRange()) {
                     FlowCompatibleRange(response.info.compatibleRange.startHeight, response.info.compatibleRange.endHeight)
-                } else null
+                } else { null }
                 FlowNodeVersionInfo(response.info.semver, response.info.commit, response.info.sporkId.toByteArray(), response.info.protocolVersion, response.info.sporkRootBlockHeight, response.info.nodeRootBlockHeight, compatibleRange)
             },
             errorMessage = "Failed to get node version info"
         )
-    }
 
-    override fun getTransactionsByBlockId(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowTransaction>>> {
-        return handleApiCall(
+    override fun getTransactionsByBlockId(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowTransaction>>> =
+        handleApiCall(
             apiCall = {
                 api.getTransactionsByBlockID(
-                    Access.GetTransactionsByBlockIDRequest.newBuilder()
+                    Access.GetTransactionsByBlockIDRequest
+                        .newBuilder()
                         .setBlockId(id.byteStringValue)
                         .build()
                 )
@@ -459,13 +455,13 @@ class AsyncFlowAccessApiImpl(
             transform = { it.transactionsList.map { FlowTransaction.of(it) } },
             errorMessage = "Failed to get transactions by block ID"
         )
-    }
 
-    override fun getTransactionResultsByBlockId(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowTransactionResult>>> {
-        return handleApiCall(
+    override fun getTransactionResultsByBlockId(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowTransactionResult>>> =
+        handleApiCall(
             apiCall = {
                 api.getTransactionResultsByBlockID(
-                    Access.GetTransactionsByBlockIDRequest.newBuilder()
+                    Access.GetTransactionsByBlockIDRequest
+                        .newBuilder()
                         .setBlockId(id.byteStringValue)
                         .build()
                 )
@@ -473,13 +469,13 @@ class AsyncFlowAccessApiImpl(
             transform = { it.transactionResultsList.map { FlowTransactionResult.of(it) } },
             errorMessage = "Failed to get transaction results by block ID"
         )
-    }
 
-    override fun getExecutionResultByBlockId(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowExecutionResult?>> {
-        return handleApiCall(
+    override fun getExecutionResultByBlockId(id: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowExecutionResult?>> =
+        handleApiCall(
             apiCall = {
                 api.getExecutionResultByID(
-                    Access.GetExecutionResultByIDRequest.newBuilder()
+                    Access.GetExecutionResultByIDRequest
+                        .newBuilder()
                         .setId(id.byteStringValue)
                         .build()
                 )
@@ -487,7 +483,6 @@ class AsyncFlowAccessApiImpl(
             transform = { if (it.hasExecutionResult()) FlowExecutionResult.of(it) else null },
             errorMessage = "Failed to get execution result by block ID"
         )
-    }
 }
 
 fun <T> completableFuture(future: ListenableFuture<T>): CompletableFuture<T> {

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -454,14 +454,28 @@ class AsyncFlowAccessApiImpl(
 
     override fun getProtocolStateSnapshotByHeight(height: Long): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowSnapshot>> =
         handleApiCall(
-            apiCall = { api.getProtocolStateSnapshotByHeight(Access.GetProtocolStateSnapshotByHeightRequest.newBuilder().setBlockHeight(height).build()) },
+            apiCall = {
+                api.getProtocolStateSnapshotByHeight(
+                    Access.GetProtocolStateSnapshotByHeightRequest
+                        .newBuilder()
+                        .setBlockHeight(height)
+                        .build()
+                )
+            },
             transform = { FlowSnapshot(it.serializedSnapshot.toByteArray()) },
             errorMessage = "Failed to get protocol state snapshot by height"
         )
 
     override fun getProtocolStateSnapshotByBlockId(blockId: FlowId): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowSnapshot>> =
         handleApiCall(
-            apiCall = { api.getProtocolStateSnapshotByBlockID(Access.GetProtocolStateSnapshotByBlockIDRequest.newBuilder().setBlockId(blockId.byteStringValue).build()) },
+            apiCall = {
+                api.getProtocolStateSnapshotByBlockID(
+                    Access.GetProtocolStateSnapshotByBlockIDRequest
+                        .newBuilder()
+                        .setBlockId(blockId.byteStringValue)
+                        .build()
+                )
+            },
             transform = { FlowSnapshot(it.serializedSnapshot.toByteArray()) },
             errorMessage = "Failed to get protocol state snapshot by block ID"
         )

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImpl.kt
@@ -338,54 +338,65 @@ class AsyncFlowAccessApiImpl(
             errorMessage = "Failed to get transaction result by index"
         )
 
-    override fun executeScriptAtLatestBlock(script: FlowScript, arguments: Iterable<ByteString>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
+    private fun executeScript(
+        apiCall: () -> ListenableFuture<Access.ExecuteScriptResponse>,
+        errorMessage: String
+    ): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
         handleApiCall(
+            apiCall = apiCall,
+            transform = { FlowScriptResponse(it.value.toByteArray()) },
+            errorMessage = errorMessage
+        )
+
+    override fun executeScriptAtLatestBlock(
+        script: FlowScript, arguments: Iterable<ByteString>
+    ): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
+        executeScript(
             apiCall = {
                 api.executeScriptAtLatestBlock(
-                    Access.ExecuteScriptAtLatestBlockRequest
-                        .newBuilder()
+                    Access.ExecuteScriptAtLatestBlockRequest.newBuilder()
                         .setScript(script.byteStringValue)
                         .addAllArguments(arguments)
                         .build()
                 )
             },
-            transform = { FlowScriptResponse(it.value.toByteArray()) },
             errorMessage = "Failed to execute script at latest block"
         )
 
-    override fun executeScriptAtBlockId(script: FlowScript, blockId: FlowId, arguments: Iterable<ByteString>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
-        handleApiCall(
+    override fun executeScriptAtBlockId(
+        script: FlowScript, blockId: FlowId, arguments: Iterable<ByteString>
+    ): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
+        executeScript(
             apiCall = {
                 api.executeScriptAtBlockID(
-                    Access.ExecuteScriptAtBlockIDRequest
-                        .newBuilder()
+                    Access.ExecuteScriptAtBlockIDRequest.newBuilder()
                         .setBlockId(blockId.byteStringValue)
                         .setScript(script.byteStringValue)
                         .addAllArguments(arguments)
                         .build()
                 )
             },
-            transform = { FlowScriptResponse(it.value.toByteArray()) },
             errorMessage = "Failed to execute script at block ID"
         )
 
-    override fun executeScriptAtBlockHeight(script: FlowScript, height: Long, arguments: Iterable<ByteString>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
-        handleApiCall(
+    override fun executeScriptAtBlockHeight(
+        script: FlowScript, height: Long, arguments: Iterable<ByteString>
+    ): CompletableFuture<FlowAccessApi.AccessApiCallResponse<FlowScriptResponse>> =
+        executeScript(
             apiCall = {
                 api.executeScriptAtBlockHeight(
-                    Access.ExecuteScriptAtBlockHeightRequest
-                        .newBuilder()
+                    Access.ExecuteScriptAtBlockHeightRequest.newBuilder()
                         .setBlockHeight(height)
                         .setScript(script.byteStringValue)
                         .addAllArguments(arguments)
                         .build()
                 )
             },
-            transform = { FlowScriptResponse(it.value.toByteArray()) },
             errorMessage = "Failed to execute script at block height"
         )
 
-    override fun getEventsForHeightRange(type: String, range: ClosedRange<Long>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowEventResult>>> =
+
+     override fun getEventsForHeightRange(type: String, range: ClosedRange<Long>): CompletableFuture<FlowAccessApi.AccessApiCallResponse<List<FlowEventResult>>> =
         handleApiCall(
             apiCall = {
                 api.getEventsForHeightRange(

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
@@ -233,6 +233,19 @@ class FlowAccessApiImpl(
             FlowAccessApi.AccessApiCallResponse.Error("Failed to get collection by ID", e)
         }
 
+    override fun getFullCollectionById(id: FlowId): FlowAccessApi.AccessApiCallResponse<List<FlowTransaction>> =
+        try {
+            val ret = api.getFullCollectionByID(
+                Access.GetFullCollectionByIDRequest
+                    .newBuilder()
+                    .setId(id.byteStringValue)
+                    .build()
+            )
+            FlowAccessApi.AccessApiCallResponse.Success(ret.transactionsList.map { FlowTransaction.of(it) })
+        } catch (e: Exception) {
+            FlowAccessApi.AccessApiCallResponse.Error("Failed to get full collection by ID", e)
+        }
+
     override fun sendTransaction(transaction: FlowTransaction): FlowAccessApi.AccessApiCallResponse<FlowId> =
         try {
             val ret = api.sendTransaction(

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
@@ -441,6 +441,32 @@ class FlowAccessApiImpl(
             FlowAccessApi.AccessApiCallResponse.Error("Failed to get latest protocol state snapshot", e)
         }
 
+    override fun getProtocolStateSnapshotByBlockId(blockId: FlowId): FlowAccessApi.AccessApiCallResponse<FlowSnapshot> =
+        try {
+            val ret = api.getProtocolStateSnapshotByBlockID(
+                Access.GetProtocolStateSnapshotByBlockIDRequest
+                    .newBuilder()
+                    .setBlockId(blockId.byteStringValue)
+                    .build()
+            )
+            FlowAccessApi.AccessApiCallResponse.Success(FlowSnapshot(ret.serializedSnapshot.toByteArray()))
+        } catch (e: Exception) {
+            FlowAccessApi.AccessApiCallResponse.Error("Failed to get protocol state snapshot by block ID", e)
+        }
+
+    override fun getProtocolStateSnapshotByHeight(height: Long): FlowAccessApi.AccessApiCallResponse<FlowSnapshot> =
+        try {
+            val ret = api.getProtocolStateSnapshotByHeight(
+                Access.GetProtocolStateSnapshotByHeightRequest
+                    .newBuilder()
+                    .setBlockHeight(height)
+                    .build()
+            )
+            FlowAccessApi.AccessApiCallResponse.Success(FlowSnapshot(ret.serializedSnapshot.toByteArray()))
+        } catch (e: Exception) {
+            FlowAccessApi.AccessApiCallResponse.Error("Failed to get protocol state snapshot by height", e)
+        }
+
     override fun getNodeVersionInfo(): FlowAccessApi.AccessApiCallResponse<FlowNodeVersionInfo> =
         try {
             val ret = api.getNodeVersionInfo(

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
@@ -1295,24 +1295,6 @@ data class FlowCollection(
         .addAllTransactionIds(transactionIds.map { it.byteStringValue })
 }
 
-data class FlowFullCollection(
-    val id: FlowId,
-    val transactionIds: List<FlowId>
-) : Serializable {
-    companion object {
-        @JvmStatic
-        fun of(value: CollectionOuterClass.Collection) = FlowCollection(
-            id = FlowId.of(value.id.toByteArray()),
-            transactionIds = value.transactionIdsList.map { FlowId.of(it.toByteArray()) }
-        )
-    }
-
-    @JvmOverloads
-    fun builder(builder: CollectionOuterClass.Collection.Builder = CollectionOuterClass.Collection.newBuilder()): CollectionOuterClass.Collection.Builder = builder
-        .setId(id.byteStringValue)
-        .addAllTransactionIds(transactionIds.map { it.byteStringValue })
-}
-
 interface BytesHolder {
     val bytes: ByteArray
     val base16Value: String get() = bytes.bytesToHex()

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/models.kt
@@ -1295,6 +1295,24 @@ data class FlowCollection(
         .addAllTransactionIds(transactionIds.map { it.byteStringValue })
 }
 
+data class FlowFullCollection(
+    val id: FlowId,
+    val transactionIds: List<FlowId>
+) : Serializable {
+    companion object {
+        @JvmStatic
+        fun of(value: CollectionOuterClass.Collection) = FlowCollection(
+            id = FlowId.of(value.id.toByteArray()),
+            transactionIds = value.transactionIdsList.map { FlowId.of(it.toByteArray()) }
+        )
+    }
+
+    @JvmOverloads
+    fun builder(builder: CollectionOuterClass.Collection.Builder = CollectionOuterClass.Collection.newBuilder()): CollectionOuterClass.Collection.Builder = builder
+        .setId(id.byteStringValue)
+        .addAllTransactionIds(transactionIds.map { it.byteStringValue })
+}
+
 interface BytesHolder {
     val bytes: ByteArray
     val base16Value: String get() = bytes.bytesToHex()

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
+import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.HEIGHT
+import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.blockId
 import org.onflow.protobuf.access.Access
 import org.onflow.protobuf.entities.AccountOuterClass
 import org.onflow.protobuf.entities.BlockExecutionDataOuterClass
@@ -388,6 +390,28 @@ class FlowAccessApiTest {
         `when`(flowAccessApi.getLatestProtocolStateSnapshot()).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(snapshot))
 
         val result = flowAccessApi.getLatestProtocolStateSnapshot()
+
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(snapshot), result)
+    }
+
+    @Test
+    fun `Test getProtocolStateSnapshotByBlockId`() {
+        val flowAccessApi = mock(FlowAccessApi::class.java)
+        val snapshot = FlowSnapshot("snapshot".toByteArray())
+        `when`(flowAccessApi.getProtocolStateSnapshotByBlockId(blockId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(snapshot))
+
+        val result = flowAccessApi.getProtocolStateSnapshotByBlockId(blockId)
+
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(snapshot), result)
+    }
+
+    @Test
+    fun `Test getProtocolStateSnapshotByHeight`() {
+        val flowAccessApi = mock(FlowAccessApi::class.java)
+        val snapshot = FlowSnapshot("snapshot".toByteArray())
+        `when`(flowAccessApi.getProtocolStateSnapshotByHeight(HEIGHT)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(snapshot))
+
+        val result = flowAccessApi.getProtocolStateSnapshotByHeight(HEIGHT)
 
         assertEquals(FlowAccessApi.AccessApiCallResponse.Success(snapshot), result)
     }

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
@@ -231,6 +231,18 @@ class FlowAccessApiTest {
     }
 
     @Test
+    fun `Test getFullCollectionById`() {
+        val flowAccessApi = mock(FlowAccessApi::class.java)
+        val flowId = FlowId("01")
+        val flowTransaction = FlowTransaction.of(TransactionOuterClass.Transaction.getDefaultInstance())
+        `when`(flowAccessApi.getFullCollectionById(flowId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(listOf(flowTransaction)))
+
+        val result = flowAccessApi.getFullCollectionById(flowId)
+
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(listOf(flowTransaction)), result)
+    }
+
+    @Test
     fun `Test sendTransaction`() {
         val flowAccessApi = mock(FlowAccessApi::class.java)
         val flowTransaction = FlowTransaction.of(TransactionOuterClass.Transaction.getDefaultInstance())

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -3,6 +3,7 @@ package org.onflow.flow.sdk.impl
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import com.google.protobuf.ByteString
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -12,6 +13,7 @@ import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.onflow.flow.sdk.*
+import org.onflow.flow.sdk.impl.FlowAccessApiImplTest.Companion.createMockAccount
 import org.onflow.protobuf.access.Access
 import org.onflow.protobuf.access.AccessAPIGrpc
 import org.onflow.protobuf.entities.AccountOuterClass
@@ -91,7 +93,16 @@ class AsyncFlowAccessApiImplTest {
         return future
     }
 
-    private object MockResponseFactory {
+    object MockResponseFactory {
+        fun accountResponse(mockAccount: FlowAccount) = Access.AccountResponse
+            .newBuilder()
+            .setAccount(mockAccount.builder().build())
+            .build()
+
+        fun getAccountResponse(mockAccount: FlowAccount) = Access.GetAccountResponse
+            .newBuilder()
+            .setAccount(mockAccount.builder().build())
+            .build()
         fun accountKeyResponse(accountKey: FlowAccountKey) = Access.AccountKeyResponse
             .newBuilder()
             .setAccountKey(accountKey.builder().build())
@@ -435,12 +446,9 @@ class AsyncFlowAccessApiImplTest {
     @Test
     fun `test getAccountByAddress`() {
         val flowAddress = FlowAddress("01")
-        val flowAccount = FlowAccount(flowAddress, BigDecimal.ONE, FlowCode("code".toByteArray()), emptyList(), emptyMap())
-        val accountResponse = Access.GetAccountResponse
-            .newBuilder()
-            .setAccount(flowAccount.builder().build())
-            .build()
-        `when`(api.getAccount(any())).thenReturn(setupFutureMock(accountResponse))
+        val flowAccount = createMockAccount(flowAddress)
+
+        `when`(api.getAccount(any())).thenReturn(setupFutureMock(MockResponseFactory.getAccountResponse(flowAccount)))
 
         val result = asyncFlowAccessApi.getAccountByAddress(flowAddress).get()
         assert(result is FlowAccessApi.AccessApiCallResponse.Success)
@@ -454,12 +462,9 @@ class AsyncFlowAccessApiImplTest {
     @Test
     fun `test getAccountAtLatestBlock`() {
         val flowAddress = FlowAddress("01")
-        val flowAccount = FlowAccount(flowAddress, BigDecimal.ONE, FlowCode("code".toByteArray()), emptyList(), emptyMap())
-        val accountResponse = Access.AccountResponse
-            .newBuilder()
-            .setAccount(flowAccount.builder().build())
-            .build()
-        `when`(api.getAccountAtLatestBlock(any())).thenReturn(setupFutureMock(accountResponse))
+        val flowAccount = createMockAccount(flowAddress)
+
+        `when`(api.getAccountAtLatestBlock(any())).thenReturn(setupFutureMock(MockResponseFactory.accountResponse(flowAccount)))
 
         val result = asyncFlowAccessApi.getAccountAtLatestBlock(flowAddress).get()
         assert(result is FlowAccessApi.AccessApiCallResponse.Success)
@@ -473,13 +478,10 @@ class AsyncFlowAccessApiImplTest {
     @Test
     fun `test getAccountByBlockHeight`() {
         val flowAddress = FlowAddress("01")
-        val flowAccount = FlowAccount(flowAddress, BigDecimal.ONE, FlowCode("code".toByteArray()), emptyList(), emptyMap())
+        val flowAccount = createMockAccount(flowAddress)
         val height = 123L
-        val accountResponse = Access.AccountResponse
-            .newBuilder()
-            .setAccount(flowAccount.builder().build())
-            .build()
-        `when`(api.getAccountAtBlockHeight(any())).thenReturn(setupFutureMock(accountResponse))
+
+        `when`(api.getAccountAtBlockHeight(any())).thenReturn(setupFutureMock(MockResponseFactory.accountResponse(flowAccount)))
 
         val result = asyncFlowAccessApi.getAccountByBlockHeight(flowAddress, height).get()
         assert(result is FlowAccessApi.AccessApiCallResponse.Success)

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -594,6 +594,24 @@ class AsyncFlowAccessApiImplTest {
     }
 
     @Test
+    fun `test getProtocolStateSnapshotByBlockId`() {
+        val mockFlowSnapshot = FlowSnapshot("test_serialized_snapshot".toByteArray())
+        `when`(api.getProtocolStateSnapshotByBlockID(any())).thenReturn(setupFutureMock(MockResponseFactory.protocolStateSnapshotResponse()))
+
+        val result = asyncFlowAccessApi.getProtocolStateSnapshotByBlockId(blockId).get()
+        assertSuccess(result, mockFlowSnapshot)
+    }
+
+    @Test
+    fun `test getProtocolStateSnapshotByHeight`() {
+        val mockFlowSnapshot = FlowSnapshot("test_serialized_snapshot".toByteArray())
+        `when`(api.getProtocolStateSnapshotByHeight(any())).thenReturn(setupFutureMock(MockResponseFactory.protocolStateSnapshotResponse()))
+
+        val result = asyncFlowAccessApi.getProtocolStateSnapshotByHeight(HEIGHT).get()
+        assertSuccess(result, mockFlowSnapshot)
+    }
+
+    @Test
     fun `test getNodeVersionInfo`() {
         val mockNodeVersionInfo = createMockNodeVersionInfo()
         `when`(api.getNodeVersionInfo(any())).thenReturn(setupFutureMock(mockNodeVersionInfo))

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -3,7 +3,6 @@ package org.onflow.flow.sdk.impl
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import com.google.protobuf.ByteString
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -19,7 +18,6 @@ import org.onflow.protobuf.access.AccessAPIGrpc
 import org.onflow.protobuf.entities.AccountOuterClass
 import org.onflow.protobuf.entities.NodeVersionInfoOuterClass
 import org.onflow.protobuf.entities.TransactionOuterClass
-import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -85,6 +83,33 @@ class AsyncFlowAccessApiImplTest {
             mockAccountKey
         )
         val testException = RuntimeException("Test exception")
+
+        fun createMockNodeVersionInfo(): Access.GetNodeVersionInfoResponse =
+            Access.GetNodeVersionInfoResponse
+                .newBuilder()
+                .setInfo(
+                    NodeVersionInfoOuterClass.NodeVersionInfo
+                        .newBuilder()
+                        .setSemver("v0.0.1")
+                        .setCommit("123456")
+                        .setSporkId(ByteString.copyFromUtf8("sporkId"))
+                        .setProtocolVersion(5)
+                        .setSporkRootBlockHeight(1000)
+                        .setNodeRootBlockHeight(1001)
+                        .setCompatibleRange(
+                            NodeVersionInfoOuterClass.CompatibleRange
+                                .newBuilder()
+                                .setStartHeight(100)
+                                .setEndHeight(200)
+                                .build()
+                        ).build()
+                ).build()
+
+        fun createTransactionsResponse(transactions: List<FlowTransaction>): Access.TransactionsResponse =
+            Access.TransactionsResponse
+                .newBuilder()
+                .addAllTransactions(transactions.map { it.builder().build() })
+                .build()
     }
 
     private fun <T> setupFutureMock(response: T): ListenableFuture<T> {
@@ -202,12 +227,6 @@ class AsyncFlowAccessApiImplTest {
                 .setReferenceBlockId(ByteString.copyFromUtf8(referenceBlockId))
                 .build()
         )
-
-    private fun createTransactionsResponse(transactions: List<FlowTransaction>): Access.TransactionsResponse =
-        Access.TransactionsResponse
-            .newBuilder()
-            .addAllTransactions(transactions.map { it.builder().build() })
-            .build()
 
     private fun <T> assertSuccess(result: FlowAccessApi.AccessApiCallResponse<T>, expected: T) {
         assert(result is FlowAccessApi.AccessApiCallResponse.Success)
@@ -643,25 +662,4 @@ class AsyncFlowAccessApiImplTest {
         executor.shutdown()
         executor.awaitTermination(2, TimeUnit.SECONDS)
     }
-
-    private fun createMockNodeVersionInfo(): Access.GetNodeVersionInfoResponse =
-        Access.GetNodeVersionInfoResponse
-            .newBuilder()
-            .setInfo(
-                NodeVersionInfoOuterClass.NodeVersionInfo
-                    .newBuilder()
-                    .setSemver("v0.0.1")
-                    .setCommit("123456")
-                    .setSporkId(ByteString.copyFromUtf8("sporkId"))
-                    .setProtocolVersion(5)
-                    .setSporkRootBlockHeight(1000)
-                    .setNodeRootBlockHeight(1001)
-                    .setCompatibleRange(
-                        NodeVersionInfoOuterClass.CompatibleRange
-                            .newBuilder()
-                            .setStartHeight(100)
-                            .setEndHeight(200)
-                            .build()
-                    ).build()
-            ).build()
 }

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -158,6 +158,11 @@ class AsyncFlowAccessApiImplTest {
             .setCollection(mockCollection.builder().build())
             .build()
 
+        fun fullCollectionResponse(transactions: List<FlowTransaction>) = Access.FullCollectionResponse
+            .newBuilder()
+            .addAllTransactions(transactions.map { it.builder().build() })
+            .build()
+
         fun executionResultResponse(mockExecutionResult: FlowExecutionResult) = Access.ExecutionResultByIDResponse
             .newBuilder()
             .setExecutionResult(mockExecutionResult.builder().build())
@@ -411,6 +416,16 @@ class AsyncFlowAccessApiImplTest {
 
         val result = asyncFlowAccessApi.getCollectionById(collectionId).get()
         assertSuccess(result, mockCollection)
+    }
+
+    @Test
+    fun `test getFullCollectionById`() {
+        val collectionId = FlowId("01")
+        val mockTransaction = FlowTransaction(FlowScript("script"), emptyList(), FlowId.of("01".toByteArray()), 123L, FlowTransactionProposalKey(FlowAddress("02"), 1, 123L), FlowAddress("02"), emptyList())
+        `when`(api.getFullCollectionByID(any())).thenReturn(setupFutureMock(MockResponseFactory.fullCollectionResponse(listOf(mockTransaction))))
+
+        val result = asyncFlowAccessApi.getFullCollectionById(collectionId).get()
+        assertSuccess(result, listOf(mockTransaction))
     }
 
     @Test

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -878,6 +878,4 @@ class FlowAccessApiImplTest {
             is FlowAccessApi.AccessApiCallResponse.Error -> throw IllegalStateException("Request failed: ${result.message}", result.throwable)
         }
     }
-
-
 }

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -13,6 +13,8 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.*
 import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.HEIGHT
 import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.blockId
+import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.createMockNodeVersionInfo
+import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.createTransactionsResponse
 import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.mockAccountKey
 import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.mockAccountKeys
 import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.mockBlock
@@ -115,12 +117,8 @@ class FlowAccessApiImplTest {
         val flowAddress = FlowAddress("01")
         val keyIndex = 0
         val blockHeight = 123L
-        val response = Access.AccountKeyResponse
-            .newBuilder()
-            .setAccountKey(mockAccountKey.builder().build())
-            .build()
 
-        `when`(mockApi.getAccountKeyAtBlockHeight(any())).thenReturn(response)
+        `when`(mockApi.getAccountKeyAtBlockHeight(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.accountKeyResponse(mockAccountKey))
 
         val result = flowAccessApiImpl.getAccountKeyAtBlockHeight(flowAddress, keyIndex, blockHeight)
         assertResultSuccess(result) { assertEquals(mockAccountKey, it) }
@@ -153,12 +151,8 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test getAccountKeysAtLatestBlock`() {
         val flowAddress = FlowAddress("01")
-        val response = Access.AccountKeysResponse
-            .newBuilder()
-            .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
-            .build()
 
-        `when`(mockApi.getAccountKeysAtLatestBlock(any())).thenReturn(response)
+        `when`(mockApi.getAccountKeysAtLatestBlock(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.accountKeysResponse(mockAccountKeys))
 
         val result = flowAccessApiImpl.getAccountKeysAtLatestBlock(flowAddress)
         assertResultSuccess(result) { assertEquals(mockAccountKeys, it) }
@@ -188,12 +182,8 @@ class FlowAccessApiImplTest {
     fun `Test getAccountKeysAtBlockHeight`() {
         val flowAddress = FlowAddress("01")
         val blockHeight = 123L
-        val response = Access.AccountKeysResponse
-            .newBuilder()
-            .addAllAccountKeys(mockAccountKeys.map { it.builder().build() })
-            .build()
 
-        `when`(mockApi.getAccountKeysAtBlockHeight(any())).thenReturn(response)
+        `when`(mockApi.getAccountKeysAtBlockHeight(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.accountKeysResponse(mockAccountKeys))
 
         val result = flowAccessApiImpl.getAccountKeysAtBlockHeight(flowAddress, blockHeight)
         assertResultSuccess(result) { assertEquals(mockAccountKeys, it) }
@@ -210,11 +200,10 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test getAccountKeysAtBlockHeight error case`() {
         val flowAddress = FlowAddress("01")
-        val blockHeight = 123L
 
         `when`(mockApi.getAccountKeysAtBlockHeight(any())).thenThrow(testException)
 
-        val result = flowAccessApiImpl.getAccountKeysAtBlockHeight(flowAddress, blockHeight)
+        val result = flowAccessApiImpl.getAccountKeysAtBlockHeight(flowAddress, HEIGHT)
 
         assertTrue(result is FlowAccessApi.AccessApiCallResponse.Error)
         assertEquals("Failed to get account keys at block height", (result as FlowAccessApi.AccessApiCallResponse.Error).message)
@@ -223,12 +212,7 @@ class FlowAccessApiImplTest {
 
     @Test
     fun `Test getLatestBlockHeader`() {
-        val blockHeaderProto = Access.BlockHeaderResponse
-            .newBuilder()
-            .setBlock(mockBlockHeader.builder().build())
-            .build()
-
-        `when`(mockApi.getLatestBlockHeader(any())).thenReturn(blockHeaderProto)
+        `when`(mockApi.getLatestBlockHeader(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.blockHeaderResponse(mockBlockHeader))
 
         val result = flowAccessApiImpl.getLatestBlockHeader(sealed = true)
         assertResultSuccess(result) { assertEquals(mockBlockHeader, it) }
@@ -236,12 +220,7 @@ class FlowAccessApiImplTest {
 
     @Test
     fun `Test getBlockHeaderById`() {
-        val blockHeaderProto = Access.BlockHeaderResponse
-            .newBuilder()
-            .setBlock(mockBlockHeader.builder().build())
-            .build()
-
-        `when`(mockApi.getBlockHeaderByID(any())).thenReturn(blockHeaderProto)
+        `when`(mockApi.getBlockHeaderByID(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.blockHeaderResponse(mockBlockHeader))
 
         val result = flowAccessApiImpl.getBlockHeaderById(blockId)
         assertResultSuccess(result) { assertEquals(mockBlockHeader, it) }
@@ -249,26 +228,15 @@ class FlowAccessApiImplTest {
 
     @Test
     fun `Test getBlockHeaderByHeight`() {
-        val height = 123L
-        val blockHeaderProto = Access.BlockHeaderResponse
-            .newBuilder()
-            .setBlock(mockBlockHeader.builder().build())
-            .build()
+        `when`(mockApi.getBlockHeaderByHeight(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.blockHeaderResponse(mockBlockHeader))
 
-        `when`(mockApi.getBlockHeaderByHeight(any())).thenReturn(blockHeaderProto)
-
-        val result = flowAccessApiImpl.getBlockHeaderByHeight(height)
+        val result = flowAccessApiImpl.getBlockHeaderByHeight(HEIGHT)
         assertResultSuccess(result) { assertEquals(mockBlockHeader, it) }
     }
 
     @Test
     fun `Test getLatestBlock`() {
-        val blockProto = Access.BlockResponse
-            .newBuilder()
-            .setBlock(mockBlock.builder().build())
-            .build()
-
-        `when`(mockApi.getLatestBlock(any())).thenReturn(blockProto)
+        `when`(mockApi.getLatestBlock(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.blockResponse(mockBlock))
 
         val result = flowAccessApiImpl.getLatestBlock(sealed = true)
         assertResultSuccess(result) { assertEquals(mockBlock, it) }
@@ -276,14 +244,7 @@ class FlowAccessApiImplTest {
 
     @Test
     fun `Test getBlockById`() {
-        val mockBlock = mockBlock
-
-        val blockProto = Access.BlockResponse
-            .newBuilder()
-            .setBlock(mockBlock.builder().build())
-            .build()
-
-        `when`(mockApi.getBlockByID(any())).thenReturn(blockProto)
+        `when`(mockApi.getBlockByID(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.blockResponse(mockBlock))
 
         val result = flowAccessApiImpl.getBlockById(blockId)
         assertResultSuccess(result) { assertEquals(mockBlock, it) }
@@ -308,12 +269,8 @@ class FlowAccessApiImplTest {
     fun `Test getAccountBalanceAtLatestBlock success`() {
         val flowAddress = FlowAddress("01")
         val expectedBalance = 1000L
-        val response = Access.AccountBalanceResponse
-            .newBuilder()
-            .setBalance(expectedBalance)
-            .build()
 
-        `when`(mockApi.getAccountBalanceAtLatestBlock(any())).thenReturn(response)
+        `when`(mockApi.getAccountBalanceAtLatestBlock(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.accountBalanceResponse(expectedBalance))
 
         val result = flowAccessApiImpl.getAccountBalanceAtLatestBlock(flowAddress)
         assertResultSuccess(result) { assertEquals(expectedBalance, it) }
@@ -342,23 +299,18 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test getAccountBalanceAtBlockHeight success`() {
         val flowAddress = FlowAddress("01")
-        val blockHeight = 123L
         val expectedBalance = 1000L
-        val response = Access.AccountBalanceResponse
-            .newBuilder()
-            .setBalance(expectedBalance)
-            .build()
 
-        `when`(mockApi.getAccountBalanceAtBlockHeight(any())).thenReturn(response)
+        `when`(mockApi.getAccountBalanceAtBlockHeight(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.accountBalanceResponse(expectedBalance))
 
-        val result = flowAccessApiImpl.getAccountBalanceAtBlockHeight(flowAddress, blockHeight)
+        val result = flowAccessApiImpl.getAccountBalanceAtBlockHeight(flowAddress, HEIGHT)
         assertResultSuccess(result) { assertEquals(expectedBalance, it) }
 
         verify(mockApi).getAccountBalanceAtBlockHeight(
             Access.GetAccountBalanceAtBlockHeightRequest
                 .newBuilder()
                 .setAddress(flowAddress.byteStringValue)
-                .setBlockHeight(blockHeight)
+                .setBlockHeight(HEIGHT)
                 .build()
         )
     }
@@ -366,11 +318,10 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test getAccountBalanceAtBlockHeight failure`() {
         val flowAddress = FlowAddress("01")
-        val blockHeight = 123L
 
         `when`(mockApi.getAccountBalanceAtBlockHeight(any())).thenThrow(testException)
 
-        val result = flowAccessApiImpl.getAccountBalanceAtBlockHeight(flowAddress, blockHeight)
+        val result = flowAccessApiImpl.getAccountBalanceAtBlockHeight(flowAddress, HEIGHT)
 
         assertTrue(result is FlowAccessApi.AccessApiCallResponse.Error)
         assertEquals("Failed to get account balance at block height", (result as FlowAccessApi.AccessApiCallResponse.Error).message)
@@ -482,15 +433,10 @@ class FlowAccessApiImplTest {
     fun `Test getAccountByBlockHeight`() {
         val flowAddress = FlowAddress("01")
         val flowAccount = createMockAccount(flowAddress)
-        val height = 123L
-        val accountProto = Access.AccountResponse
-            .newBuilder()
-            .setAccount(flowAccount.builder().build())
-            .build()
 
-        `when`(mockApi.getAccountAtBlockHeight(any())).thenReturn(accountProto)
+        `when`(mockApi.getAccountAtBlockHeight(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.accountResponse(flowAccount))
 
-        val result = flowAccessApiImpl.getAccountByBlockHeight(flowAddress, height)
+        val result = flowAccessApiImpl.getAccountByBlockHeight(flowAddress, HEIGHT)
         assertResultSuccess(result) {
             assertEquals(flowAccount.address, it.address)
             assertEquals(flowAccount.keys, it.keys)
@@ -503,12 +449,8 @@ class FlowAccessApiImplTest {
     fun `Test executeScriptAtLatestBlock`() {
         val script = FlowScript("script".toByteArray())
         val arguments = listOf(ByteString.copyFromUtf8("argument1"), ByteString.copyFromUtf8("argument2"))
-        val response = Access.ExecuteScriptResponse
-            .newBuilder()
-            .setValue(ByteString.copyFromUtf8("response_value"))
-            .build()
 
-        `when`(mockApi.executeScriptAtLatestBlock(any())).thenReturn(response)
+        `when`(mockApi.executeScriptAtLatestBlock(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.scriptResponse())
 
         val result = flowAccessApiImpl.executeScriptAtLatestBlock(script, arguments)
         assertResultSuccess(result) { assertEquals("response_value", it.stringValue) }
@@ -526,12 +468,8 @@ class FlowAccessApiImplTest {
     fun `Test executeScriptAtBlockId`() {
         val script = FlowScript("some_script")
         val arguments = listOf(ByteString.copyFromUtf8("argument1"), ByteString.copyFromUtf8("argument2"))
-        val response = Access.ExecuteScriptResponse
-            .newBuilder()
-            .setValue(ByteString.copyFromUtf8("response_value"))
-            .build()
 
-        `when`(mockApi.executeScriptAtBlockID(any())).thenReturn(response)
+        `when`(mockApi.executeScriptAtBlockID(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.scriptResponse())
 
         val result = flowAccessApiImpl.executeScriptAtBlockId(script, blockId, arguments)
         assertResultSuccess(result) { assertEquals("response_value", it.stringValue) }
@@ -550,12 +488,8 @@ class FlowAccessApiImplTest {
     fun `Test executeScriptAtBlockHeight`() {
         val script = FlowScript("some_script")
         val arguments = listOf(ByteString.copyFromUtf8("argument1"), ByteString.copyFromUtf8("argument2"))
-        val response = Access.ExecuteScriptResponse
-            .newBuilder()
-            .setValue(ByteString.copyFromUtf8("response_value"))
-            .build()
 
-        `when`(mockApi.executeScriptAtBlockHeight(any())).thenReturn(response)
+        `when`(mockApi.executeScriptAtBlockHeight(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.scriptResponse())
 
         val result = flowAccessApiImpl.executeScriptAtBlockHeight(script, HEIGHT, arguments)
         assertResultSuccess(result) { assertEquals("response_value", it.stringValue) }
@@ -626,12 +560,8 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test getNetworkParameters`() {
         val mockFlowChainId = FlowChainId.of("test_chain_id")
-        val response = Access.GetNetworkParametersResponse
-            .newBuilder()
-            .setChainId("test_chain_id")
-            .build()
 
-        `when`(mockApi.getNetworkParameters(Access.GetNetworkParametersRequest.newBuilder().build())).thenReturn(response)
+        `when`(mockApi.getNetworkParameters(Access.GetNetworkParametersRequest.newBuilder().build())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.networkParametersResponse())
 
         val result = flowAccessApiImpl.getNetworkParameters()
         assertResultSuccess(result) { assertEquals(mockFlowChainId, it) }
@@ -640,12 +570,8 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test getLatestProtocolStateSnapshot`() {
         val mockFlowSnapshot = FlowSnapshot("test_serialized_snapshot".toByteArray())
-        val response = Access.ProtocolStateSnapshotResponse
-            .newBuilder()
-            .setSerializedSnapshot(ByteString.copyFromUtf8("test_serialized_snapshot"))
-            .build()
 
-        `when`(mockApi.getLatestProtocolStateSnapshot(Access.GetLatestProtocolStateSnapshotRequest.newBuilder().build())).thenReturn(response)
+        `when`(mockApi.getLatestProtocolStateSnapshot(Access.GetLatestProtocolStateSnapshotRequest.newBuilder().build())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.protocolStateSnapshotResponse())
 
         val result = flowAccessApiImpl.getLatestProtocolStateSnapshot()
         assertResultSuccess(result) { assertEquals(mockFlowSnapshot, it) }
@@ -653,25 +579,7 @@ class FlowAccessApiImplTest {
 
     @Test
     fun `Test getNodeVersionInfo`() {
-        val mockNodeVersionInfo = Access.GetNodeVersionInfoResponse
-            .newBuilder()
-            .setInfo(
-                NodeVersionInfoOuterClass.NodeVersionInfo
-                    .newBuilder()
-                    .setSemver("v0.0.1")
-                    .setCommit("123456")
-                    .setSporkId(ByteString.copyFromUtf8("sporkId"))
-                    .setProtocolVersion(5)
-                    .setSporkRootBlockHeight(1000)
-                    .setNodeRootBlockHeight(1001)
-                    .setCompatibleRange(
-                        NodeVersionInfoOuterClass.CompatibleRange
-                            .newBuilder()
-                            .setStartHeight(100)
-                            .setEndHeight(200)
-                            .build()
-                    ).build()
-            ).build()
+        val mockNodeVersionInfo = createMockNodeVersionInfo()
 
         `when`(mockApi.getNodeVersionInfo(any())).thenReturn(mockNodeVersionInfo)
 
@@ -692,11 +600,7 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test getTransactionsByBlockId`() {
         val transactions = listOf(FlowTransaction.of(TransactionOuterClass.Transaction.getDefaultInstance()))
-        val response = Access.TransactionsResponse
-            .newBuilder()
-            .addAllTransactions(transactions.map { it.builder().build() })
-            .build()
-
+        val response = createTransactionsResponse(transactions)
         `when`(mockApi.getTransactionsByBlockID(any())).thenReturn(response)
 
         val result = flowAccessApiImpl.getTransactionsByBlockId(blockId)
@@ -713,10 +617,7 @@ class FlowAccessApiImplTest {
                 .build()
         )
         val transactions = listOf(transaction1, transaction2)
-        val response = Access.TransactionsResponse
-            .newBuilder()
-            .addAllTransactions(transactions.map { it.builder().build() })
-            .build()
+        val response = createTransactionsResponse(transactions)
 
         `when`(mockApi.getTransactionsByBlockID(any())).thenReturn(response)
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -581,7 +581,14 @@ class FlowAccessApiImplTest {
     fun `Test getProtocolStateSnapshotByBlockId`() {
         val mockFlowSnapshot = FlowSnapshot("test_serialized_snapshot".toByteArray())
 
-        `when`(mockApi.getProtocolStateSnapshotByBlockID(Access.GetProtocolStateSnapshotByBlockIDRequest.newBuilder().setBlockId(blockId.byteStringValue).build())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.protocolStateSnapshotResponse())
+        `when`(
+            mockApi.getProtocolStateSnapshotByBlockID(
+                Access.GetProtocolStateSnapshotByBlockIDRequest
+                    .newBuilder()
+                    .setBlockId(blockId.byteStringValue)
+                    .build()
+            )
+        ).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.protocolStateSnapshotResponse())
 
         val result = flowAccessApiImpl.getProtocolStateSnapshotByBlockId(blockId)
         assertResultSuccess(result) { assertEquals(mockFlowSnapshot, it) }
@@ -591,7 +598,14 @@ class FlowAccessApiImplTest {
     fun `Test getProtocolStateSnapshotByHeight`() {
         val mockFlowSnapshot = FlowSnapshot("test_serialized_snapshot".toByteArray())
 
-        `when`(mockApi.getProtocolStateSnapshotByHeight(Access.GetProtocolStateSnapshotByHeightRequest.newBuilder().setBlockHeight(HEIGHT).build())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.protocolStateSnapshotResponse())
+        `when`(
+            mockApi.getProtocolStateSnapshotByHeight(
+                Access.GetProtocolStateSnapshotByHeightRequest
+                    .newBuilder()
+                    .setBlockHeight(HEIGHT)
+                    .build()
+            )
+        ).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.protocolStateSnapshotResponse())
 
         val result = flowAccessApiImpl.getProtocolStateSnapshotByHeight(HEIGHT)
         assertResultSuccess(result) { assertEquals(mockFlowSnapshot, it) }

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -578,6 +578,26 @@ class FlowAccessApiImplTest {
     }
 
     @Test
+    fun `Test getProtocolStateSnapshotByBlockId`() {
+        val mockFlowSnapshot = FlowSnapshot("test_serialized_snapshot".toByteArray())
+
+        `when`(mockApi.getProtocolStateSnapshotByBlockID(Access.GetProtocolStateSnapshotByBlockIDRequest.newBuilder().setBlockId(blockId.byteStringValue).build())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.protocolStateSnapshotResponse())
+
+        val result = flowAccessApiImpl.getProtocolStateSnapshotByBlockId(blockId)
+        assertResultSuccess(result) { assertEquals(mockFlowSnapshot, it) }
+    }
+
+    @Test
+    fun `Test getProtocolStateSnapshotByHeight`() {
+        val mockFlowSnapshot = FlowSnapshot("test_serialized_snapshot".toByteArray())
+
+        `when`(mockApi.getProtocolStateSnapshotByHeight(Access.GetProtocolStateSnapshotByHeightRequest.newBuilder().setBlockHeight(HEIGHT).build())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.protocolStateSnapshotResponse())
+
+        val result = flowAccessApiImpl.getProtocolStateSnapshotByHeight(HEIGHT)
+        assertResultSuccess(result) { assertEquals(mockFlowSnapshot, it) }
+    }
+
+    @Test
     fun `Test getNodeVersionInfo`() {
         val mockNodeVersionInfo = createMockNodeVersionInfo()
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.*
+import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.testException
 import org.onflow.protobuf.access.Access
 import org.onflow.protobuf.access.AccessAPIGrpc
 import org.onflow.protobuf.entities.*
@@ -898,10 +899,9 @@ class FlowAccessApiImplTest {
     @Test
     fun `Test subscribeExecutionDataByBlockHeight error case`() = runTest {
         val blockHeight = 100L
-        val exception = RuntimeException("Test exception")
 
         `when`(mockExecutionDataApi.subscribeExecutionDataFromStartBlockHeight(any()))
-            .thenAnswer { throw exception }
+            .thenAnswer { throw testException }
 
         val (_, errorChannel) = flowAccessApiImpl.subscribeExecutionDataByBlockHeight(this, blockHeight)
 
@@ -913,7 +913,7 @@ class FlowAccessApiImplTest {
         job.join()
 
         if (receivedException != null) {
-            assertEquals(exception.message, receivedException!!.message)
+            assertEquals(testException.message, receivedException!!.message)
         } else {
             fail("Expected error but got success")
         }

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImplTest.kt
@@ -340,6 +340,17 @@ class FlowAccessApiImplTest {
     }
 
     @Test
+    fun `Test getFullCollectionById`() {
+        val collectionId = FlowId("01")
+        val mockTransaction = createMockTransaction()
+
+        `when`(mockApi.getFullCollectionByID(any())).thenReturn(AsyncFlowAccessApiImplTest.MockResponseFactory.fullCollectionResponse(listOf(mockTransaction)))
+
+        val result = flowAccessApiImpl.getFullCollectionById(collectionId)
+        assertResultSuccess(result) { assertEquals(listOf(mockTransaction), it) }
+    }
+
+    @Test
     fun `Test sendTransaction`() {
         val mockTransaction = createMockTransaction()
 


### PR DESCRIPTION
Closes: #138 

## Description

Addresses code duplication in error handling and tests related to the `FlowAccessApi` and `AsyncFlowAccessApi` classes (see issue #138)

- Also addressed refactoring comments suggested by Code Rabbit
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new methods for retrieving full collections and protocol state snapshots by ID and height.
	- Added utility functions for improved error handling in API calls.

- **Bug Fixes**
	- Streamlined error handling in various API methods to reduce redundancy.

- **Refactor**
	- Refactored existing tests to utilize new helper functions for better maintainability and readability.
	- Enhanced the structure and clarity of the test code by centralizing mock object creation.

- **Chores**
	- Updated visibility of mock response factory for broader access in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->