### PR TITLE
#114  Streaming endpoints code duplication, general refactoring

### DIFF
--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/AccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/AccessAPIConnectorTest.kt
@@ -15,7 +15,6 @@ import java.math.BigDecimal
 
 @FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
 internal class AccessAPIConnectorTest {
-
     // user key pairs using all supported signing algorithms
     private val userKeyPairs = arrayOf(
         Crypto.generateKeyPair(SignatureAlgorithm.ECDSA_P256),
@@ -62,7 +61,6 @@ internal class AccessAPIConnectorTest {
         val accessAPIConnector = AccessAPIConnector(senderKey, accessAPI)
         accessAPIConnector.transferTokens(sender, to, amount)
     }
-
 
     @Test
     fun `Can transfer tokens to other account`() {

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/AccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/AccessAPIConnectorTest.kt
@@ -15,6 +15,7 @@ import java.math.BigDecimal
 
 @FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
 internal class AccessAPIConnectorTest {
+
     // user key pairs using all supported signing algorithms
     private val userKeyPairs = arrayOf(
         Crypto.generateKeyPair(SignatureAlgorithm.ECDSA_P256),
@@ -61,6 +62,7 @@ internal class AccessAPIConnectorTest {
         val accessAPIConnector = AccessAPIConnector(senderKey, accessAPI)
         accessAPIConnector.transferTokens(sender, to, amount)
     }
+
 
     @Test
     fun `Can transfer tokens to other account`() {

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getAccountBalance/GetAccountBalanceAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getAccountBalance/GetAccountBalanceAccessAPIConnectorTest.kt
@@ -3,11 +3,13 @@ package org.onflow.examples.kotlin.getAccountBalance
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.onflow.examples.kotlin.getTransaction.GetTransactionAccessAPIConnectorTest
 import org.onflow.flow.common.test.FlowEmulatorProjectTest
 import org.onflow.flow.common.test.FlowServiceAccountCredentials
 import org.onflow.flow.common.test.FlowTestClient
 import org.onflow.flow.common.test.TestAccount
 import org.onflow.flow.sdk.FlowAccessApi
+import org.onflow.flow.sdk.FlowBlock
 
 @FlowEmulatorProjectTest(flowJsonLocation = "../flow/flow.json")
 internal class GetAccountBalanceAccessAPIConnectorTest {
@@ -18,10 +20,12 @@ internal class GetAccountBalanceAccessAPIConnectorTest {
     lateinit var accessAPI: FlowAccessApi
 
     private lateinit var balanceAPIConnector: GetAccountBalanceAccessAPIConnector
+    private lateinit var latestBlock: FlowBlock
 
     @BeforeEach
     fun setup() {
         balanceAPIConnector = GetAccountBalanceAccessAPIConnector(accessAPI)
+        latestBlock = GetTransactionAccessAPIConnectorTest.fetchLatestBlockWithRetries(accessAPI)
     }
 
     @Test
@@ -36,17 +40,10 @@ internal class GetAccountBalanceAccessAPIConnectorTest {
     @Test
     fun `Can fetch account balance at a specific block height`() {
         val address = serviceAccount.flowAddress
-        val latestBlock = accessAPI.getLatestBlock(true) // Fetch the latest sealed block
+        val balanceAtHeight = balanceAPIConnector.getBalanceAtBlockHeight(address, latestBlock.height)
 
-        when (latestBlock) {
-            is FlowAccessApi.AccessApiCallResponse.Success -> {
-                val balanceAtHeight = balanceAPIConnector.getBalanceAtBlockHeight(address, latestBlock.data.height)
-
-                Assertions.assertNotNull(balanceAtHeight, "Balance at specific block height should not be null")
-                Assertions.assertTrue(balanceAtHeight >= 0, "Balance at specific block height should be non-negative")
-            }
-            is FlowAccessApi.AccessApiCallResponse.Error -> Assertions.fail("Failed to retrieve the latest block: ${latestBlock.message}")
-        }
+        Assertions.assertNotNull(balanceAtHeight, "Balance at specific block height should not be null")
+        Assertions.assertTrue(balanceAtHeight >= 0, "Balance at specific block height should be non-negative")
     }
 
     @Test
@@ -56,18 +53,11 @@ internal class GetAccountBalanceAccessAPIConnectorTest {
         // Fetch balance at latest block
         val balanceAtLatest = balanceAPIConnector.getBalanceAtLatestBlock(address)
 
-        // Fetch latest block height
-        val latestBlock = accessAPI.getLatestBlock(true)
-        when (latestBlock) {
-            is FlowAccessApi.AccessApiCallResponse.Success -> {
-                val blockHeight = latestBlock.data.height
+        val blockHeight = latestBlock.height
 
-                // Fetch balance at the same block height
-                val balanceAtHeight = balanceAPIConnector.getBalanceAtBlockHeight(address, blockHeight)
+        // Fetch balance at the same block height
+        val balanceAtHeight = balanceAPIConnector.getBalanceAtBlockHeight(address, blockHeight)
 
-                Assertions.assertEquals(balanceAtLatest, balanceAtHeight, "Balance at latest block and specific block height should match")
-            }
-            is FlowAccessApi.AccessApiCallResponse.Error -> Assertions.fail("Failed to retrieve the latest block: ${latestBlock.message}")
-        }
+        Assertions.assertEquals(balanceAtLatest, balanceAtHeight, "Balance at latest block and specific block height should match")
     }
 }

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getCollection/GetCollectionAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getCollection/GetCollectionAccessAPIConnectorTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.onflow.examples.kotlin.AccessAPIConnector
+import org.onflow.examples.kotlin.getTransaction.GetTransactionAccessAPIConnectorTest
 import org.onflow.flow.common.test.FlowEmulatorProjectTest
 import org.onflow.flow.common.test.FlowServiceAccountCredentials
 import org.onflow.flow.common.test.FlowTestClient
@@ -23,6 +24,7 @@ class GetCollectionAccessAPIConnectorTest {
     private lateinit var accessAPIConnector: AccessAPIConnector
 
     private lateinit var collectionId: FlowId
+    lateinit var block: FlowBlock
 
     @BeforeEach
     fun setup() {
@@ -36,10 +38,7 @@ class GetCollectionAccessAPIConnectorTest {
             publicKey
         )
 
-        val block = when (val response = accessAPI.getLatestBlock()) {
-            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
-            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
-        }
+        block = GetTransactionAccessAPIConnectorTest.fetchLatestBlockWithRetries(accessAPI)
         collectionId = block.collectionGuarantees.first().id
     }
 

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getProtocolState/GetProtocolStateAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getProtocolState/GetProtocolStateAccessAPIConnectorTest.kt
@@ -38,7 +38,6 @@ internal class GetProtocolStateAccessAPIConnectorTest {
 
     @Test
     fun `Can get protocol state snapshot by height`() {
-
         val latestSnapshot: FlowSnapshot = protocolStateConnector.getProtocolStateSnapshotByHeight(block.height)
         assertNotNull(latestSnapshot, ("Snapshot should not be null"))
     }

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getProtocolState/GetProtocolStateAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getProtocolState/GetProtocolStateAccessAPIConnectorTest.kt
@@ -3,6 +3,7 @@ package org.onflow.examples.kotlin.getProtocolState
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.onflow.examples.kotlin.getTransaction.GetTransactionAccessAPIConnectorTest
 import org.onflow.flow.common.test.FlowEmulatorProjectTest
 import org.onflow.flow.common.test.FlowTestClient
 import org.onflow.flow.sdk.FlowAccessApi
@@ -20,6 +21,7 @@ internal class GetProtocolStateAccessAPIConnectorTest {
     @BeforeEach
     fun setup() {
         protocolStateConnector = GetProtocolStateAccessAPIConnector(accessAPI)
+        block = GetTransactionAccessAPIConnectorTest.fetchLatestBlockWithRetries(accessAPI)
     }
 
     @Test
@@ -30,21 +32,12 @@ internal class GetProtocolStateAccessAPIConnectorTest {
 
     @Test
     fun `Can get protocol state snapshot by blockId`() {
-        block = when (val response = accessAPI.getLatestBlock()) {
-            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
-            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
-        }
-
         val latestSnapshot: FlowSnapshot = protocolStateConnector.getProtocolStateSnapshotByBlockId(block.id)
         assertNotNull(latestSnapshot, ("Snapshot should not be null"))
     }
 
     @Test
     fun `Can get protocol state snapshot by height`() {
-        block = when (val response = accessAPI.getLatestBlock()) {
-            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
-            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
-        }
 
         val latestSnapshot: FlowSnapshot = protocolStateConnector.getProtocolStateSnapshotByHeight(block.height)
         assertNotNull(latestSnapshot, ("Snapshot should not be null"))

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnectorTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.onflow.examples.kotlin.AccessAPIConnector
-import org.onflow.examples.kotlin.AccessAPIConnectorTest
 import org.onflow.flow.common.test.FlowEmulatorProjectTest
 import org.onflow.flow.common.test.FlowServiceAccountCredentials
 import org.onflow.flow.common.test.FlowTestClient
@@ -68,7 +67,7 @@ internal class GetTransactionAccessAPIConnectorTest {
     }
 
     companion object {
-        fun fetchLatestBlockWithRetries(accessAPI : FlowAccessApi, retries: Int = 5, delayMillis: Long = 500): FlowBlock {
+        fun fetchLatestBlockWithRetries(accessAPI: FlowAccessApi, retries: Int = 5, delayMillis: Long = 500): FlowBlock {
             repeat(retries) { attempt ->
                 when (val response = accessAPI.getLatestBlock()) {
                     is FlowAccessApi.AccessApiCallResponse.Success -> return response.data

--- a/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnectorTest.kt
+++ b/kotlin-example/src/test/kotlin/org/onflow/examples/kotlin/getTransaction/GetTransactionAccessAPIConnectorTest.kt
@@ -1,9 +1,12 @@
 package org.onflow.examples.kotlin.getTransaction
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.onflow.examples.kotlin.AccessAPIConnector
+import org.onflow.examples.kotlin.AccessAPIConnectorTest
 import org.onflow.flow.common.test.FlowEmulatorProjectTest
 import org.onflow.flow.common.test.FlowServiceAccountCredentials
 import org.onflow.flow.common.test.FlowTestClient
@@ -37,10 +40,7 @@ internal class GetTransactionAccessAPIConnectorTest {
             publicKey
         )
 
-        block = when (val response = accessAPI.getLatestBlock()) {
-            is FlowAccessApi.AccessApiCallResponse.Success -> response.data
-            is FlowAccessApi.AccessApiCallResponse.Error -> throw Exception(response.message, response.throwable)
-        }
+        block = fetchLatestBlockWithRetries(accessAPI)
     }
 
     @Test
@@ -65,5 +65,20 @@ internal class GetTransactionAccessAPIConnectorTest {
 
         assertNotNull(transactionResult, "Transaction result should not be null")
         assertTrue(transactionResult.status === FlowTransactionStatus.SEALED, "Transaction should be sealed")
+    }
+
+    companion object {
+        fun fetchLatestBlockWithRetries(accessAPI : FlowAccessApi, retries: Int = 5, delayMillis: Long = 500): FlowBlock {
+            repeat(retries) { attempt ->
+                when (val response = accessAPI.getLatestBlock()) {
+                    is FlowAccessApi.AccessApiCallResponse.Success -> return response.data
+                    is FlowAccessApi.AccessApiCallResponse.Error -> {
+                        println("Attempt ${attempt + 1} failed: ${response.message}. Retrying...")
+                        runBlocking { delay(delayMillis) }
+                    }
+                }
+            }
+            throw Exception("Failed to retrieve the latest block after $retries attempts.")
+        }
     }
 }

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
@@ -24,367 +24,361 @@ class FlowAccessApiImpl(
         }
     }
 
-    override fun ping(): FlowAccessApi.AccessApiCallResponse<Unit> =
-        try {
-            api.ping(
-                Access.PingRequest
-                    .newBuilder()
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(Unit)
+    private fun <T> executeWithResponse(action: () -> T, errorMessage: String): FlowAccessApi.AccessApiCallResponse<T> {
+        return try {
+            FlowAccessApi.AccessApiCallResponse.Success(action())
         } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to ping", e)
+            FlowAccessApi.AccessApiCallResponse.Error(errorMessage, e)
         }
+    }
+
+    override fun ping(): FlowAccessApi.AccessApiCallResponse<Unit> =
+        executeWithResponse(
+            action = {
+                api.ping(
+                    Access.PingRequest.newBuilder().build()
+                )
+                Unit
+            },
+            errorMessage = "Failed to ping"
+        )
 
     override fun getAccountKeyAtLatestBlock(address: FlowAddress, keyIndex: Int): FlowAccessApi.AccessApiCallResponse<FlowAccountKey> =
-        try {
-            val ret = api.getAccountKeyAtLatestBlock(
-                Access.GetAccountKeyAtLatestBlockRequest
-                    .newBuilder()
-                    .setAddress(address.byteStringValue)
-                    .setIndex(keyIndex)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(FlowAccountKey.of(ret.accountKey))
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at latest block", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getAccountKeyAtLatestBlock(
+                    Access.GetAccountKeyAtLatestBlockRequest
+                        .newBuilder()
+                        .setAddress(address.byteStringValue)
+                        .setIndex(keyIndex)
+                        .build()
+                )
+                FlowAccountKey.of(ret.accountKey)
+            },
+            errorMessage = "Failed to get account key at latest block"
+        )
 
     override fun getAccountKeyAtBlockHeight(address: FlowAddress, keyIndex: Int, height: Long): FlowAccessApi.AccessApiCallResponse<FlowAccountKey> =
-        try {
-            val ret = api.getAccountKeyAtBlockHeight(
-                Access.GetAccountKeyAtBlockHeightRequest
-                    .newBuilder()
-                    .setAddress(address.byteStringValue)
-                    .setIndex(keyIndex)
-                    .setBlockHeight(height)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(FlowAccountKey.of(ret.accountKey))
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account key at block height", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getAccountKeyAtBlockHeight(
+                    Access.GetAccountKeyAtBlockHeightRequest
+                        .newBuilder()
+                        .setAddress(address.byteStringValue)
+                        .setIndex(keyIndex)
+                        .setBlockHeight(height)
+                        .build()
+                )
+                FlowAccountKey.of(ret.accountKey)
+            },
+            errorMessage = "Failed to get account key at block height"
+        )
 
     override fun getAccountKeysAtLatestBlock(address: FlowAddress): FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>> =
-        try {
-            val ret = api.getAccountKeysAtLatestBlock(
-                Access.GetAccountKeysAtLatestBlockRequest
-                    .newBuilder()
-                    .setAddress(address.byteStringValue)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(ret.accountKeysList.map { FlowAccountKey.of(it) })
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at latest block", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getAccountKeysAtLatestBlock(
+                    Access.GetAccountKeysAtLatestBlockRequest
+                        .newBuilder()
+                        .setAddress(address.byteStringValue)
+                        .build()
+                )
+                ret.accountKeysList.map { FlowAccountKey.of(it) }
+            },
+            errorMessage = "Failed to get account keys at latest block"
+        )
 
     override fun getAccountKeysAtBlockHeight(address: FlowAddress, height: Long): FlowAccessApi.AccessApiCallResponse<List<FlowAccountKey>> =
-        try {
-            val ret = api.getAccountKeysAtBlockHeight(
-                Access.GetAccountKeysAtBlockHeightRequest
-                    .newBuilder()
-                    .setAddress(address.byteStringValue)
-                    .setBlockHeight(height)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(ret.accountKeysList.map { FlowAccountKey.of(it) })
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account keys at block height", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getAccountKeysAtBlockHeight(
+                    Access.GetAccountKeysAtBlockHeightRequest
+                        .newBuilder()
+                        .setAddress(address.byteStringValue)
+                        .setBlockHeight(height)
+                        .build()
+                )
+                ret.accountKeysList.map { FlowAccountKey.of(it) }
+            },
+            errorMessage = "Failed to get account keys at block height"
+        )
 
     override fun getLatestBlockHeader(sealed: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlockHeader> =
-        try {
-            val ret = api.getLatestBlockHeader(
-                Access.GetLatestBlockHeaderRequest
-                    .newBuilder()
-                    .setIsSealed(sealed)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(FlowBlockHeader.of(ret.block))
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get latest block header", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getLatestBlockHeader(
+                    Access.GetLatestBlockHeaderRequest
+                        .newBuilder()
+                        .setIsSealed(sealed)
+                        .build()
+                )
+                FlowBlockHeader.of(ret.block)
+            },
+            errorMessage = "Failed to get latest block header"
+        )
 
     override fun getBlockHeaderById(id: FlowId): FlowAccessApi.AccessApiCallResponse<FlowBlockHeader> =
-        try {
-            val ret = api.getBlockHeaderByID(
-                Access.GetBlockHeaderByIDRequest
-                    .newBuilder()
-                    .setId(id.byteStringValue)
-                    .build()
-            )
-            if (ret.hasBlock()) {
-                FlowAccessApi.AccessApiCallResponse.Success(FlowBlockHeader.of(ret.block))
-            } else {
-                FlowAccessApi.AccessApiCallResponse.Error("Block header not found")
-            }
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get block header by ID", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getBlockHeaderByID(
+                    Access.GetBlockHeaderByIDRequest
+                        .newBuilder()
+                        .setId(id.byteStringValue)
+                        .build()
+                )
+                if (ret.hasBlock()) FlowBlockHeader.of(ret.block) else throw Exception("Block header not found")
+            },
+            errorMessage = "Failed to get block header by ID"
+        )
 
     override fun getBlockHeaderByHeight(height: Long): FlowAccessApi.AccessApiCallResponse<FlowBlockHeader> =
-        try {
-            val ret = api.getBlockHeaderByHeight(
-                Access.GetBlockHeaderByHeightRequest
-                    .newBuilder()
-                    .setHeight(height)
-                    .build()
-            )
-            if (ret.hasBlock()) {
-                FlowAccessApi.AccessApiCallResponse.Success(FlowBlockHeader.of(ret.block))
-            } else {
-                FlowAccessApi.AccessApiCallResponse.Error("Block header not found")
-            }
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get block header by height", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getBlockHeaderByHeight(
+                    Access.GetBlockHeaderByHeightRequest
+                        .newBuilder()
+                        .setHeight(height)
+                        .build()
+                )
+                if (ret.hasBlock()) FlowBlockHeader.of(ret.block) else throw Exception("Block header not found")
+            },
+            errorMessage = "Failed to get block header by height"
+        )
+
 
     override fun getLatestBlock(sealed: Boolean, fullBlockResponse: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlock> =
-        try {
-            val ret = api.getLatestBlock(
-                Access.GetLatestBlockRequest
-                    .newBuilder()
-                    .setIsSealed(sealed)
-                    .setFullBlockResponse(fullBlockResponse)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(FlowBlock.of(ret.block))
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get latest block", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getLatestBlock(
+                    Access.GetLatestBlockRequest
+                        .newBuilder()
+                        .setIsSealed(sealed)
+                        .setFullBlockResponse(fullBlockResponse)
+                        .build()
+                )
+                FlowBlock.of(ret.block)
+            },
+            errorMessage = "Failed to get latest block"
+        )
 
     override fun getAccountBalanceAtLatestBlock(address: FlowAddress): FlowAccessApi.AccessApiCallResponse<Long> =
-        try {
-            val ret = api.getAccountBalanceAtLatestBlock(
-                Access.GetAccountBalanceAtLatestBlockRequest
-                    .newBuilder()
-                    .setAddress(address.byteStringValue)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(ret.balance)
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account balance at latest block", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getAccountBalanceAtLatestBlock(
+                    Access.GetAccountBalanceAtLatestBlockRequest
+                        .newBuilder()
+                        .setAddress(address.byteStringValue)
+                        .build()
+                )
+                ret.balance
+            },
+            errorMessage = "Failed to get account balance at latest block"
+        )
 
     override fun getAccountBalanceAtBlockHeight(address: FlowAddress, height: Long): FlowAccessApi.AccessApiCallResponse<Long> =
-        try {
-            val ret = api.getAccountBalanceAtBlockHeight(
-                Access.GetAccountBalanceAtBlockHeightRequest
-                    .newBuilder()
-                    .setAddress(address.byteStringValue)
-                    .setBlockHeight(height)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(ret.balance)
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account balance at block height", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getAccountBalanceAtBlockHeight(
+                    Access.GetAccountBalanceAtBlockHeightRequest
+                        .newBuilder()
+                        .setAddress(address.byteStringValue)
+                        .setBlockHeight(height)
+                        .build()
+                )
+                ret.balance
+            },
+            errorMessage = "Failed to get account balance at block height"
+        )
+
 
     override fun getBlockById(id: FlowId, fullBlockResponse: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlock> =
-        try {
-            val ret = api.getBlockByID(
-                Access.GetBlockByIDRequest
-                    .newBuilder()
-                    .setId(id.byteStringValue)
-                    .setFullBlockResponse(fullBlockResponse)
-                    .build()
-            )
-            if (ret.hasBlock()) {
-                FlowAccessApi.AccessApiCallResponse.Success(FlowBlock.of(ret.block))
-            } else {
-                FlowAccessApi.AccessApiCallResponse.Error("Block not found")
-            }
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get block by ID", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getBlockByID(
+                    Access.GetBlockByIDRequest
+                        .newBuilder()
+                        .setId(id.byteStringValue)
+                        .setFullBlockResponse(fullBlockResponse)
+                        .build()
+                )
+                if (ret.hasBlock()) FlowBlock.of(ret.block) else throw Exception("Block not found")
+            },
+            errorMessage = "Failed to get block by ID"
+        )
 
     override fun getBlockByHeight(height: Long, fullBlockResponse: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlock> =
-        try {
-            val ret = api.getBlockByHeight(
-                Access.GetBlockByHeightRequest
-                    .newBuilder()
-                    .setHeight(height)
-                    .setFullBlockResponse(fullBlockResponse)
-                    .build()
-            )
-            if (ret.hasBlock()) {
-                FlowAccessApi.AccessApiCallResponse.Success(FlowBlock.of(ret.block))
-            } else {
-                FlowAccessApi.AccessApiCallResponse.Error("Block not found")
-            }
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get block by height", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getBlockByHeight(
+                    Access.GetBlockByHeightRequest
+                        .newBuilder()
+                        .setHeight(height)
+                        .setFullBlockResponse(fullBlockResponse)
+                        .build()
+                )
+                if (ret.hasBlock()) FlowBlock.of(ret.block) else throw Exception("Block not found")
+            },
+            errorMessage = "Failed to get block by height"
+        )
 
     override fun getCollectionById(id: FlowId): FlowAccessApi.AccessApiCallResponse<FlowCollection> =
-        try {
-            val ret = api.getCollectionByID(
-                Access.GetCollectionByIDRequest
-                    .newBuilder()
-                    .setId(id.byteStringValue)
-                    .build()
-            )
-            if (ret.hasCollection()) {
-                FlowAccessApi.AccessApiCallResponse.Success(FlowCollection.of(ret.collection))
-            } else {
-                FlowAccessApi.AccessApiCallResponse.Error("Collection not found")
-            }
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get collection by ID", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getCollectionByID(
+                    Access.GetCollectionByIDRequest
+                        .newBuilder()
+                        .setId(id.byteStringValue)
+                        .build()
+                )
+                if (ret.hasCollection()) FlowCollection.of(ret.collection) else throw Exception("Collection not found")
+            },
+            errorMessage = "Failed to get collection by ID"
+        )
 
     override fun getFullCollectionById(id: FlowId): FlowAccessApi.AccessApiCallResponse<List<FlowTransaction>> =
-        try {
-            val ret = api.getFullCollectionByID(
-                Access.GetFullCollectionByIDRequest
-                    .newBuilder()
-                    .setId(id.byteStringValue)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(ret.transactionsList.map { FlowTransaction.of(it) })
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get full collection by ID", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getFullCollectionByID(
+                    Access.GetFullCollectionByIDRequest
+                        .newBuilder()
+                        .setId(id.byteStringValue)
+                        .build()
+                )
+                ret.transactionsList.map { FlowTransaction.of(it) }
+            },
+            errorMessage = "Failed to get full collection by ID"
+        )
 
     override fun sendTransaction(transaction: FlowTransaction): FlowAccessApi.AccessApiCallResponse<FlowId> =
-        try {
-            val ret = api.sendTransaction(
-                Access.SendTransactionRequest
-                    .newBuilder()
-                    .setTransaction(transaction.builder().build())
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(FlowId.of(ret.id.toByteArray()))
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to send transaction", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.sendTransaction(
+                    Access.SendTransactionRequest
+                        .newBuilder()
+                        .setTransaction(transaction.builder().build())
+                        .build()
+                )
+                FlowId.of(ret.id.toByteArray())
+            },
+            errorMessage = "Failed to send transaction"
+        )
 
     override fun getTransactionById(id: FlowId): FlowAccessApi.AccessApiCallResponse<FlowTransaction> =
-        try {
-            val ret = api.getTransaction(
-                Access.GetTransactionRequest
-                    .newBuilder()
-                    .setId(id.byteStringValue)
-                    .build()
-            )
-            if (ret.hasTransaction()) {
-                FlowAccessApi.AccessApiCallResponse.Success(FlowTransaction.of(ret.transaction))
-            } else {
-                FlowAccessApi.AccessApiCallResponse.Error("Transaction not found")
-            }
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction by ID", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getTransaction(
+                    Access.GetTransactionRequest
+                        .newBuilder()
+                        .setId(id.byteStringValue)
+                        .build()
+                )
+                if (ret.hasTransaction()) FlowTransaction.of(ret.transaction) else throw Exception("Transaction not found")
+            },
+            errorMessage = "Failed to get transaction by ID"
+        )
+
 
     override fun getTransactionResultById(id: FlowId): FlowAccessApi.AccessApiCallResponse<FlowTransactionResult> =
-        try {
-            val ret = api.getTransactionResult(
-                Access.GetTransactionRequest
-                    .newBuilder()
-                    .setId(id.byteStringValue)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(FlowTransactionResult.of(ret))
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by ID", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getTransactionResult(
+                    Access.GetTransactionRequest
+                        .newBuilder()
+                        .setId(id.byteStringValue)
+                        .build()
+                )
+                FlowTransactionResult.of(ret)
+            },
+            errorMessage = "Failed to get transaction result by ID"
+        )
 
     override fun getTransactionResultByIndex(blockId: FlowId, index: Int): FlowAccessApi.AccessApiCallResponse<FlowTransactionResult> =
-        try {
-            val ret = api.getTransactionResultByIndex(
-                Access.GetTransactionByIndexRequest
-                    .newBuilder()
-                    .setBlockId(blockId.byteStringValue)
-                    .setIndex(index)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(FlowTransactionResult.of(ret))
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get transaction result by index", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getTransactionResultByIndex(
+                    Access.GetTransactionByIndexRequest
+                        .newBuilder()
+                        .setBlockId(blockId.byteStringValue)
+                        .setIndex(index)
+                        .build()
+                )
+                FlowTransactionResult.of(ret)
+            },
+            errorMessage = "Failed to get transaction result by index"
+        )
 
     override fun getSystemTransaction(blockId: FlowId): FlowAccessApi.AccessApiCallResponse<FlowTransaction> =
-        try {
-            val ret = api.getSystemTransaction(
-                Access.GetSystemTransactionRequest
-                    .newBuilder()
-                    .setBlockId(blockId.byteStringValue)
-                    .build()
-            )
-            if (ret.hasTransaction()) {
-                FlowAccessApi.AccessApiCallResponse.Success(FlowTransaction.of(ret.transaction))
-            } else {
-                FlowAccessApi.AccessApiCallResponse.Error("System transaction not found")
-            }
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get system transaction by block ID", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getSystemTransaction(
+                    Access.GetSystemTransactionRequest
+                        .newBuilder()
+                        .setBlockId(blockId.byteStringValue)
+                        .build()
+                )
+                if (ret.hasTransaction()) FlowTransaction.of(ret.transaction) else throw Exception("System transaction not found")
+            },
+            errorMessage = "Failed to get system transaction by block ID"
+        )
 
     override fun getSystemTransactionResult(blockId: FlowId): FlowAccessApi.AccessApiCallResponse<FlowTransactionResult> =
-        try {
-            val ret = api.getSystemTransactionResult(
-                Access.GetSystemTransactionResultRequest
-                    .newBuilder()
-                    .setBlockId(blockId.byteStringValue)
-                    .build()
-            )
-            FlowAccessApi.AccessApiCallResponse.Success(FlowTransactionResult.of(ret))
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get system transaction result by block ID", e)
-        }
+        executeWithResponse(
+            action = {
+                val ret = api.getSystemTransactionResult(
+                    Access.GetSystemTransactionResultRequest
+                        .newBuilder()
+                        .setBlockId(blockId.byteStringValue)
+                        .build()
+                )
+                FlowTransactionResult.of(ret)
+            },
+            errorMessage = "Failed to get system transaction result by block ID"
+        )
+
 
     @Deprecated("Behaves identically to getAccountAtLatestBlock", replaceWith = ReplaceWith("getAccountAtLatestBlock"))
-    override fun getAccountByAddress(addresss: FlowAddress): FlowAccessApi.AccessApiCallResponse<FlowAccount> =
-        try {
-            val ret = api.getAccount(
-                Access.GetAccountRequest
-                    .newBuilder()
-                    .setAddress(addresss.byteStringValue)
-                    .build()
-            )
-            if (ret.hasAccount()) {
-                FlowAccessApi.AccessApiCallResponse.Success(FlowAccount.of(ret.account))
-            } else {
-                FlowAccessApi.AccessApiCallResponse.Error("Account not found")
-            }
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account by address", e)
-        }
+    override fun getAccountByAddress(address: FlowAddress): FlowAccessApi.AccessApiCallResponse<FlowAccount> =
+        executeWithResponse(
+            action = {
+                val ret = api.getAccount(
+                    Access.GetAccountRequest
+                        .newBuilder()
+                        .setAddress(address.byteStringValue)
+                        .build()
+                )
+                if (ret.hasAccount()) FlowAccount.of(ret.account) else throw Exception("Account not found")
+            },
+            errorMessage = "Failed to get account by address"
+        )
 
-    override fun getAccountAtLatestBlock(addresss: FlowAddress): FlowAccessApi.AccessApiCallResponse<FlowAccount> =
-        try {
-            val ret = api.getAccountAtLatestBlock(
-                Access.GetAccountAtLatestBlockRequest
-                    .newBuilder()
-                    .setAddress(addresss.byteStringValue)
-                    .build()
-            )
-            if (ret.hasAccount()) {
-                FlowAccessApi.AccessApiCallResponse.Success(FlowAccount.of(ret.account))
-            } else {
-                FlowAccessApi.AccessApiCallResponse.Error("Account not found")
-            }
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account at latest block", e)
-        }
+    override fun getAccountAtLatestBlock(address: FlowAddress): FlowAccessApi.AccessApiCallResponse<FlowAccount> =
+        executeWithResponse(
+            action = {
+                val ret = api.getAccountAtLatestBlock(
+                    Access.GetAccountAtLatestBlockRequest
+                        .newBuilder()
+                        .setAddress(address.byteStringValue)
+                        .build()
+                )
+                if (ret.hasAccount()) FlowAccount.of(ret.account) else throw Exception("Account not found")
+            },
+            errorMessage = "Failed to get account at latest block"
+        )
 
-    override fun getAccountByBlockHeight(addresss: FlowAddress, height: Long): FlowAccessApi.AccessApiCallResponse<FlowAccount> =
-        try {
-            val ret = api.getAccountAtBlockHeight(
-                Access.GetAccountAtBlockHeightRequest
-                    .newBuilder()
-                    .setAddress(addresss.byteStringValue)
-                    .setBlockHeight(height)
-                    .build()
-            )
-            if (ret.hasAccount()) {
-                FlowAccessApi.AccessApiCallResponse.Success(FlowAccount.of(ret.account))
-            } else {
-                FlowAccessApi.AccessApiCallResponse.Error("Account not found")
-            }
-        } catch (e: Exception) {
-            FlowAccessApi.AccessApiCallResponse.Error("Failed to get account by block height", e)
-        }
+    override fun getAccountByBlockHeight(address: FlowAddress, height: Long): FlowAccessApi.AccessApiCallResponse<FlowAccount> =
+        executeWithResponse(
+            action = {
+                val ret = api.getAccountAtBlockHeight(
+                    Access.GetAccountAtBlockHeightRequest
+                        .newBuilder()
+                        .setAddress(address.byteStringValue)
+                        .setBlockHeight(height)
+                        .build()
+                )
+                if (ret.hasAccount()) FlowAccount.of(ret.account) else throw Exception("Account not found")
+            },
+            errorMessage = "Failed to get account by block height"
+        )
 
     override fun executeScriptAtLatestBlock(script: FlowScript, arguments: Iterable<ByteString>): FlowAccessApi.AccessApiCallResponse<FlowScriptResponse> =
         try {

--- a/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
+++ b/sdk/src/main/kotlin/org/onflow/flow/sdk/impl/FlowAccessApiImpl.kt
@@ -24,13 +24,12 @@ class FlowAccessApiImpl(
         }
     }
 
-    private fun <T> executeWithResponse(action: () -> T, errorMessage: String): FlowAccessApi.AccessApiCallResponse<T> {
-        return try {
+    private fun <T> executeWithResponse(action: () -> T, errorMessage: String): FlowAccessApi.AccessApiCallResponse<T> =
+        try {
             FlowAccessApi.AccessApiCallResponse.Success(action())
         } catch (e: Exception) {
             FlowAccessApi.AccessApiCallResponse.Error(errorMessage, e)
         }
-    }
 
     override fun ping(): FlowAccessApi.AccessApiCallResponse<Unit> =
         executeWithResponse(
@@ -145,7 +144,6 @@ class FlowAccessApiImpl(
             errorMessage = "Failed to get block header by height"
         )
 
-
     override fun getLatestBlock(sealed: Boolean, fullBlockResponse: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlock> =
         executeWithResponse(
             action = {
@@ -189,7 +187,6 @@ class FlowAccessApiImpl(
             },
             errorMessage = "Failed to get account balance at block height"
         )
-
 
     override fun getBlockById(id: FlowId, fullBlockResponse: Boolean): FlowAccessApi.AccessApiCallResponse<FlowBlock> =
         executeWithResponse(
@@ -277,7 +274,6 @@ class FlowAccessApiImpl(
             errorMessage = "Failed to get transaction by ID"
         )
 
-
     override fun getTransactionResultById(id: FlowId): FlowAccessApi.AccessApiCallResponse<FlowTransactionResult> =
         executeWithResponse(
             action = {
@@ -334,7 +330,6 @@ class FlowAccessApiImpl(
             },
             errorMessage = "Failed to get system transaction result by block ID"
         )
-
 
     @Deprecated("Behaves identically to getAccountAtLatestBlock", replaceWith = ReplaceWith("getAccountAtLatestBlock"))
     override fun getAccountByAddress(address: FlowAddress): FlowAccessApi.AccessApiCallResponse<FlowAccount> =

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
@@ -1,227 +1,188 @@
 package org.onflow.flow.sdk
 
 import com.google.protobuf.ByteString
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.HEIGHT
 import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.blockId
+import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.mockAccountKey
+import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.mockAccountKeys
+import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.mockBlock
+import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.mockBlockHeader
+import org.onflow.flow.sdk.impl.AsyncFlowAccessApiImplTest.Companion.testException
+import org.onflow.flow.sdk.impl.FlowAccessApiImplTest.Companion.createMockAccount
+import org.onflow.flow.sdk.impl.FlowAccessApiImplTest.Companion.createMockTransaction
 import org.onflow.protobuf.access.Access
-import org.onflow.protobuf.entities.AccountOuterClass
 import org.onflow.protobuf.entities.BlockExecutionDataOuterClass
-import org.onflow.protobuf.entities.BlockHeaderOuterClass
-import org.onflow.protobuf.entities.BlockOuterClass
 import org.onflow.protobuf.entities.EventOuterClass
-import org.onflow.protobuf.entities.TransactionOuterClass
 
 class FlowAccessApiTest {
+    private lateinit var flowAccessApi: FlowAccessApi
+    private val address = FlowAddress("01")
+    private val keyIndex = 0
+    private val height = HEIGHT
+    private val expectedBalance = 1000L
+    private val account = createMockAccount(address)
+    private val transaction = createMockTransaction()
+
+    @BeforeEach
+    fun setUp() {
+        flowAccessApi = mock(FlowAccessApi::class.java)
+    }
+
     @Test
     fun `Test getAccountKeyAtLatestBlock`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val address = FlowAddress("01")
-        val keyIndex = 0
-        val accountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
-
-        `when`(flowAccessApi.getAccountKeyAtLatestBlock(address, keyIndex)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(accountKey))
+        `when`(flowAccessApi.getAccountKeyAtLatestBlock(address, keyIndex)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(mockAccountKey))
 
         val result = flowAccessApi.getAccountKeyAtLatestBlock(address, keyIndex)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(accountKey), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(mockAccountKey), result)
         verify(flowAccessApi).getAccountKeyAtLatestBlock(address, keyIndex)
     }
 
     @Test
     fun `Test getAccountKeyAtBlockHeight`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val address = FlowAddress("01")
-        val keyIndex = 0
-        val height = 123L
-        val accountKey = FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
-
-        `when`(flowAccessApi.getAccountKeyAtBlockHeight(address, keyIndex, height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(accountKey))
+        `when`(flowAccessApi.getAccountKeyAtBlockHeight(address, keyIndex, height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(mockAccountKey))
 
         val result = flowAccessApi.getAccountKeyAtBlockHeight(address, keyIndex, height)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(accountKey), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(mockAccountKey), result)
         verify(flowAccessApi).getAccountKeyAtBlockHeight(address, keyIndex, height)
     }
 
     @Test
     fun `Test getAccountKeysAtLatestBlock`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val address = FlowAddress("01")
-        val accountKeys = listOf(
-            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
-            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
-        )
-
-        `when`(flowAccessApi.getAccountKeysAtLatestBlock(address)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(accountKeys))
+        `when`(flowAccessApi.getAccountKeysAtLatestBlock(address)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(mockAccountKeys))
 
         val result = flowAccessApi.getAccountKeysAtLatestBlock(address)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(accountKeys), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(mockAccountKeys), result)
         verify(flowAccessApi).getAccountKeysAtLatestBlock(address)
     }
 
     @Test
     fun `Test getAccountKeysAtBlockHeight`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val address = FlowAddress("01")
-        val height = 123L
-        val accountKeys = listOf(
-            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance()),
-            FlowAccountKey.of(AccountOuterClass.AccountKey.getDefaultInstance())
-        )
-
-        `when`(flowAccessApi.getAccountKeysAtBlockHeight(address, height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(accountKeys))
+        `when`(flowAccessApi.getAccountKeysAtBlockHeight(address, height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(mockAccountKeys))
 
         val result = flowAccessApi.getAccountKeysAtBlockHeight(address, height)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(accountKeys), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(mockAccountKeys), result)
         verify(flowAccessApi).getAccountKeysAtBlockHeight(address, height)
     }
 
     @Test
     fun `Test getLatestBlockHeader`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val latestBlockHeader = FlowBlockHeader.of(BlockHeaderOuterClass.BlockHeader.getDefaultInstance())
-        `when`(flowAccessApi.getLatestBlockHeader(true)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(latestBlockHeader))
+        `when`(flowAccessApi.getLatestBlockHeader(true)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(mockBlockHeader))
 
         val result = flowAccessApi.getLatestBlockHeader()
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(latestBlockHeader), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(mockBlockHeader), result)
     }
 
     @Test
     fun `Test getBlockHeaderById`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val blockId = FlowId("01")
-        val blockHeader = FlowBlockHeader.of(BlockHeaderOuterClass.BlockHeader.getDefaultInstance())
-        `when`(flowAccessApi.getBlockHeaderById(blockId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(blockHeader))
+        `when`(flowAccessApi.getBlockHeaderById(blockId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(mockBlockHeader))
 
         val result = flowAccessApi.getBlockHeaderById(blockId)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(blockHeader), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(mockBlockHeader), result)
     }
 
     @Test
     fun `Test getBlockHeaderByHeight`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val height = 123L
-        val blockHeader = FlowBlockHeader.of(BlockHeaderOuterClass.BlockHeader.getDefaultInstance())
-        `when`(flowAccessApi.getBlockHeaderByHeight(height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(blockHeader))
+        `when`(flowAccessApi.getBlockHeaderByHeight(height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(mockBlockHeader))
 
         val result = flowAccessApi.getBlockHeaderByHeight(height)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(blockHeader), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(mockBlockHeader), result)
     }
 
     @Test
     fun `Test getLatestBlock`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val latestBlock = FlowBlock.of(BlockOuterClass.Block.getDefaultInstance())
-        `when`(flowAccessApi.getLatestBlock(true)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(latestBlock))
+        `when`(flowAccessApi.getLatestBlock(true)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(mockBlock))
 
         val result = flowAccessApi.getLatestBlock()
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(latestBlock), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(mockBlock), result)
     }
 
     @Test
     fun `Test getBlockById`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val blockId = FlowId("01")
-        val block = FlowBlock.of(BlockOuterClass.Block.getDefaultInstance())
-        `when`(flowAccessApi.getBlockById(blockId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(block))
+        `when`(flowAccessApi.getBlockById(blockId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(mockBlock))
 
         val result = flowAccessApi.getBlockById(blockId)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(block), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(mockBlock), result)
     }
 
     @Test
     fun `Test getBlockByHeight`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val height = 123L
-        val block = FlowBlock.of(BlockOuterClass.Block.getDefaultInstance())
-        `when`(flowAccessApi.getBlockByHeight(height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(block))
+        `when`(flowAccessApi.getBlockByHeight(height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(mockBlock))
 
         val result = flowAccessApi.getBlockByHeight(height)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(block), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(mockBlock), result)
     }
 
     @Test
     fun `Test getAccountBalanceAtLatestBlock success`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowAddress = FlowAddress("01")
-        val expectedBalance = 1000L
         val response = FlowAccessApi.AccessApiCallResponse.Success(expectedBalance)
 
-        `when`(flowAccessApi.getAccountBalanceAtLatestBlock(flowAddress)).thenReturn(response)
+        `when`(flowAccessApi.getAccountBalanceAtLatestBlock(address)).thenReturn(response)
 
-        val result = flowAccessApi.getAccountBalanceAtLatestBlock(flowAddress)
+        val result = flowAccessApi.getAccountBalanceAtLatestBlock(address)
 
         assertEquals(response, result)
-        verify(flowAccessApi).getAccountBalanceAtLatestBlock(flowAddress)
+        verify(flowAccessApi).getAccountBalanceAtLatestBlock(address)
     }
 
     @Test
     fun `Test getAccountBalanceAtLatestBlock failure`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowAddress = FlowAddress("01")
-        val exception = RuntimeException("Test exception")
-        val response = FlowAccessApi.AccessApiCallResponse.Error("Failed to get account balance at latest block", exception)
+        val response = FlowAccessApi.AccessApiCallResponse.Error("Failed to get account balance at latest block", testException)
 
-        `when`(flowAccessApi.getAccountBalanceAtLatestBlock(flowAddress)).thenReturn(response)
+        `when`(flowAccessApi.getAccountBalanceAtLatestBlock(address)).thenReturn(response)
 
-        val result = flowAccessApi.getAccountBalanceAtLatestBlock(flowAddress)
+        val result = flowAccessApi.getAccountBalanceAtLatestBlock(address)
 
         assertEquals(response, result)
-        verify(flowAccessApi).getAccountBalanceAtLatestBlock(flowAddress)
+        verify(flowAccessApi).getAccountBalanceAtLatestBlock(address)
     }
 
     @Test
     fun `Test getAccountBalanceAtBlockHeight success`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowAddress = FlowAddress("01")
-        val blockHeight = 123L
-        val expectedBalance = 1000L
         val response = FlowAccessApi.AccessApiCallResponse.Success(expectedBalance)
 
-        `when`(flowAccessApi.getAccountBalanceAtBlockHeight(flowAddress, blockHeight)).thenReturn(response)
+        `when`(flowAccessApi.getAccountBalanceAtBlockHeight(address, height)).thenReturn(response)
 
-        val result = flowAccessApi.getAccountBalanceAtBlockHeight(flowAddress, blockHeight)
+        val result = flowAccessApi.getAccountBalanceAtBlockHeight(address, height)
 
         assertEquals(response, result)
-        verify(flowAccessApi).getAccountBalanceAtBlockHeight(flowAddress, blockHeight)
+        verify(flowAccessApi).getAccountBalanceAtBlockHeight(address, height)
     }
 
     @Test
     fun `Test getAccountBalanceAtBlockHeight failure`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowAddress = FlowAddress("01")
-        val blockHeight = 123L
-        val exception = RuntimeException("Test exception")
-        val response = FlowAccessApi.AccessApiCallResponse.Error("Failed to get account balance at block height", exception)
+        val response = FlowAccessApi.AccessApiCallResponse.Error("Failed to get account balance at block height", testException)
 
-        `when`(flowAccessApi.getAccountBalanceAtBlockHeight(flowAddress, blockHeight)).thenReturn(response)
+        `when`(flowAccessApi.getAccountBalanceAtBlockHeight(address, height)).thenReturn(response)
 
-        val result = flowAccessApi.getAccountBalanceAtBlockHeight(flowAddress, blockHeight)
+        val result = flowAccessApi.getAccountBalanceAtBlockHeight(address, height)
 
         assertEquals(response, result)
-        verify(flowAccessApi).getAccountBalanceAtBlockHeight(flowAddress, blockHeight)
+        verify(flowAccessApi).getAccountBalanceAtBlockHeight(address, height)
     }
 
     @Test
     fun `Test getCollectionById`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowId = FlowId("01")
+        val flowId = blockId
         val flowCollection = FlowCollection(flowId, emptyList())
         `when`(flowAccessApi.getCollectionById(flowId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowCollection))
 
@@ -232,44 +193,37 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getFullCollectionById`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowId = FlowId("01")
-        val flowTransaction = FlowTransaction.of(TransactionOuterClass.Transaction.getDefaultInstance())
-        `when`(flowAccessApi.getFullCollectionById(flowId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(listOf(flowTransaction)))
+        val flowId = blockId
+        `when`(flowAccessApi.getFullCollectionById(flowId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(listOf(transaction)))
 
         val result = flowAccessApi.getFullCollectionById(flowId)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(listOf(flowTransaction)), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(listOf(transaction)), result)
     }
 
     @Test
     fun `Test sendTransaction`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowTransaction = FlowTransaction.of(TransactionOuterClass.Transaction.getDefaultInstance())
-        val flowId = FlowId("01")
-        `when`(flowAccessApi.sendTransaction(flowTransaction)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowId))
+        val flowId = blockId
+        `when`(flowAccessApi.sendTransaction(transaction)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowId))
 
-        val result = flowAccessApi.sendTransaction(flowTransaction)
+        val result = flowAccessApi.sendTransaction(transaction)
 
         assertEquals(FlowAccessApi.AccessApiCallResponse.Success(flowId), result)
     }
 
     @Test
     fun `Test getTransactionById`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowId = FlowId("01")
-        val flowTransaction = FlowTransaction.of(TransactionOuterClass.Transaction.getDefaultInstance())
-        `when`(flowAccessApi.getTransactionById(flowId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowTransaction))
+        val flowId = blockId
+        `when`(flowAccessApi.getTransactionById(flowId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(transaction))
 
         val result = flowAccessApi.getTransactionById(flowId)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(flowTransaction), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(transaction), result)
     }
 
     @Test
     fun `Test getTransactionResultById`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowId = FlowId("01")
+        val flowId = blockId
         val flowTransactionResult = FlowTransactionResult.of(Access.TransactionResultResponse.getDefaultInstance())
         `when`(flowAccessApi.getTransactionResultById(flowId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowTransactionResult))
 
@@ -280,20 +234,17 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getSystemTransaction`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowId = FlowId("01")
-        val flowTransaction = FlowTransaction.of(TransactionOuterClass.Transaction.getDefaultInstance())
-        `when`(flowAccessApi.getSystemTransaction(flowId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowTransaction))
+        val flowId = blockId
+        `when`(flowAccessApi.getSystemTransaction(flowId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(transaction))
 
         val result = flowAccessApi.getSystemTransaction(flowId)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(flowTransaction), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(transaction), result)
     }
 
     @Test
     fun `Test getSystemTransactionResult`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowId = FlowId("01")
+        val flowId = blockId
         val flowTransactionResult = FlowTransactionResult.of(Access.TransactionResultResponse.getDefaultInstance())
         `when`(flowAccessApi.getSystemTransactionResult(flowId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowTransactionResult))
 
@@ -304,46 +255,35 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getTransactionResultByIndex`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowId = FlowId("01")
-        val index = 0
-
+        val flowId = blockId
         val flowTransactionResult = FlowTransactionResult.of(Access.TransactionResultResponse.getDefaultInstance())
-        `when`(flowAccessApi.getTransactionResultByIndex(flowId, index)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowTransactionResult))
+        `when`(flowAccessApi.getTransactionResultByIndex(flowId, keyIndex)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowTransactionResult))
 
-        val result = flowAccessApi.getTransactionResultByIndex(flowId, index)
+        val result = flowAccessApi.getTransactionResultByIndex(flowId, keyIndex)
 
         assertEquals(FlowAccessApi.AccessApiCallResponse.Success(flowTransactionResult), result)
     }
 
     @Test
     fun `Test getAccountAtLatestBlock`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowAddress = FlowAddress("01")
-        val flowAccount = FlowAccount.of(AccountOuterClass.Account.getDefaultInstance())
-        `when`(flowAccessApi.getAccountAtLatestBlock(flowAddress)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowAccount))
+        `when`(flowAccessApi.getAccountAtLatestBlock(address)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(account))
 
-        val result = flowAccessApi.getAccountAtLatestBlock(flowAddress)
+        val result = flowAccessApi.getAccountAtLatestBlock(address)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(flowAccount), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(account), result)
     }
 
     @Test
     fun `Test getAccountByBlockHeight`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowAddress = FlowAddress("01")
-        val height = 123L
-        val flowAccount = FlowAccount.of(AccountOuterClass.Account.getDefaultInstance())
-        `when`(flowAccessApi.getAccountByBlockHeight(flowAddress, height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(flowAccount))
+        `when`(flowAccessApi.getAccountByBlockHeight(address, height)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(account))
 
-        val result = flowAccessApi.getAccountByBlockHeight(flowAddress, height)
+        val result = flowAccessApi.getAccountByBlockHeight(address, height)
 
-        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(flowAccount), result)
+        assertEquals(FlowAccessApi.AccessApiCallResponse.Success(account), result)
     }
 
     @Test
     fun `Test executeScriptAtLatestBlock`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
         val script = FlowScript("script")
         val arguments = listOf(ByteString.copyFromUtf8("argument1"))
         val response = FlowScriptResponse("response".toByteArray())
@@ -356,9 +296,7 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test executeScriptAtBlockId`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
         val script = FlowScript("script")
-        val blockId = FlowId("01")
         val arguments = listOf(ByteString.copyFromUtf8("argument1"))
         val response = FlowScriptResponse("response".toByteArray())
         `when`(flowAccessApi.executeScriptAtBlockId(script, blockId, arguments)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(response))
@@ -370,9 +308,7 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test executeScriptAtBlockHeight`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
         val script = FlowScript("script")
-        val height = 123L
         val arguments = listOf(ByteString.copyFromUtf8("argument1"))
         val response = FlowScriptResponse("response".toByteArray())
         `when`(flowAccessApi.executeScriptAtBlockHeight(script, height, arguments)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(response))
@@ -384,7 +320,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getEventsForHeightRange`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
         val type = "eventType"
         val range = 100L..200L
         val eventResults = listOf(FlowEventResult.of(Access.EventsResponse.Result.getDefaultInstance()), FlowEventResult.of(Access.EventsResponse.Result.getDefaultInstance()))
@@ -397,7 +332,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getEventsForBlockIds`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
         val type = "eventType"
         val ids = setOf(FlowId("01"), FlowId("02"))
         val eventResults = listOf(FlowEventResult.of(Access.EventsResponse.Result.getDefaultInstance()), FlowEventResult.of(Access.EventsResponse.Result.getDefaultInstance()))
@@ -410,7 +344,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getNetworkParameters`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
         val chainId = FlowChainId.TESTNET
         `when`(flowAccessApi.getNetworkParameters()).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(chainId))
 
@@ -421,7 +354,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getLatestProtocolStateSnapshot`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
         val snapshot = FlowSnapshot("snapshot".toByteArray())
         `when`(flowAccessApi.getLatestProtocolStateSnapshot()).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(snapshot))
 
@@ -432,7 +364,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getProtocolStateSnapshotByBlockId`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
         val snapshot = FlowSnapshot("snapshot".toByteArray())
         `when`(flowAccessApi.getProtocolStateSnapshotByBlockId(blockId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(snapshot))
 
@@ -443,7 +374,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getProtocolStateSnapshotByHeight`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
         val snapshot = FlowSnapshot("snapshot".toByteArray())
         `when`(flowAccessApi.getProtocolStateSnapshotByHeight(HEIGHT)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(snapshot))
 
@@ -454,9 +384,7 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getTransactionsByBlockId`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val blockId = FlowId("01")
-        val transactions = listOf(FlowTransaction.of(TransactionOuterClass.Transaction.getDefaultInstance()))
+        val transactions = listOf(transaction)
         `when`(flowAccessApi.getTransactionsByBlockId(blockId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(transactions))
 
         val result = flowAccessApi.getTransactionsByBlockId(blockId)
@@ -466,9 +394,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getTransactionsByBlockId with multiple results`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val blockId = FlowId("01")
-
         val transaction1 = FlowTransaction(FlowScript("script1"), emptyList(), FlowId.of("01".toByteArray()), 123L, FlowTransactionProposalKey(FlowAddress("02"), 1, 123L), FlowAddress("02"), emptyList())
 
         val transaction2 = FlowTransaction(FlowScript("script2"), emptyList(), FlowId.of("02".toByteArray()), 456L, FlowTransactionProposalKey(FlowAddress("03"), 2, 456L), FlowAddress("03"), emptyList())
@@ -488,8 +413,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getTransactionResultsByBlockId`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val blockId = FlowId("01")
         val transactionResults = listOf(FlowTransactionResult.of(Access.TransactionResultResponse.getDefaultInstance()))
         `when`(flowAccessApi.getTransactionResultsByBlockId(blockId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(transactionResults))
 
@@ -500,8 +423,7 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getTransactionResultsByBlockId with multiple results`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val flowId = FlowId("01")
+        val flowId = blockId
 
         val transactionResult1 = FlowTransactionResult(
             FlowTransactionStatus.SEALED,
@@ -548,8 +470,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getExecutionResultByBlockId`() {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val blockId = FlowId("01")
         val executionResult = FlowExecutionResult.of(Access.ExecutionResultByIDResponse.getDefaultInstance())
         `when`(flowAccessApi.getExecutionResultByBlockId(blockId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(executionResult))
 
@@ -560,8 +480,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test subscribeExecutionDataByBlockId`(): Unit = runBlocking {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val blockId = FlowId("01")
         val scope = this
         val responseChannel = Channel<FlowBlockExecutionData>(Channel.UNLIMITED)
         val errorChannel = Channel<Throwable>(Channel.UNLIMITED)
@@ -594,7 +512,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test subscribeExecutionDataByBlockHeight`(): Unit = runBlocking {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
         val blockHeight = 100L
         val scope = this
         val responseChannel = Channel<FlowBlockExecutionData>(Channel.UNLIMITED)
@@ -628,8 +545,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test subscribeEventsByBlockId`(): Unit = runBlocking {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
-        val blockId = FlowId("01")
         val scope = this
         val responseChannel = Channel<List<FlowEvent>>(Channel.UNLIMITED)
         val errorChannel = Channel<Throwable>(Channel.UNLIMITED)
@@ -662,7 +577,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test subscribeEventsByBlockHeight`(): Unit = runBlocking {
-        val flowAccessApi = mock(FlowAccessApi::class.java)
         val blockHeight = 100L
         val scope = this
         val responseChannel = Channel<List<FlowEvent>>(Channel.UNLIMITED)

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/FlowAccessApiTest.kt
@@ -1,7 +1,6 @@
 package org.onflow.flow.sdk
 
 import com.google.protobuf.ByteString
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
@@ -32,6 +31,10 @@ class FlowAccessApiTest {
     private val expectedBalance = 1000L
     private val account = createMockAccount(address)
     private val transaction = createMockTransaction()
+    private val script = FlowScript("script")
+    private val arguments = listOf(ByteString.copyFromUtf8("argument1"))
+    private val response = FlowScriptResponse("response".toByteArray())
+    private val snapshot = FlowSnapshot("snapshot".toByteArray())
 
     @BeforeEach
     fun setUp() {
@@ -284,9 +287,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test executeScriptAtLatestBlock`() {
-        val script = FlowScript("script")
-        val arguments = listOf(ByteString.copyFromUtf8("argument1"))
-        val response = FlowScriptResponse("response".toByteArray())
         `when`(flowAccessApi.executeScriptAtLatestBlock(script, arguments)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(response))
 
         val result = flowAccessApi.executeScriptAtLatestBlock(script, arguments)
@@ -296,9 +296,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test executeScriptAtBlockId`() {
-        val script = FlowScript("script")
-        val arguments = listOf(ByteString.copyFromUtf8("argument1"))
-        val response = FlowScriptResponse("response".toByteArray())
         `when`(flowAccessApi.executeScriptAtBlockId(script, blockId, arguments)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(response))
 
         val result = flowAccessApi.executeScriptAtBlockId(script, blockId, arguments)
@@ -308,9 +305,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test executeScriptAtBlockHeight`() {
-        val script = FlowScript("script")
-        val arguments = listOf(ByteString.copyFromUtf8("argument1"))
-        val response = FlowScriptResponse("response".toByteArray())
         `when`(flowAccessApi.executeScriptAtBlockHeight(script, height, arguments)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(response))
 
         val result = flowAccessApi.executeScriptAtBlockHeight(script, height, arguments)
@@ -354,7 +348,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getLatestProtocolStateSnapshot`() {
-        val snapshot = FlowSnapshot("snapshot".toByteArray())
         `when`(flowAccessApi.getLatestProtocolStateSnapshot()).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(snapshot))
 
         val result = flowAccessApi.getLatestProtocolStateSnapshot()
@@ -364,7 +357,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getProtocolStateSnapshotByBlockId`() {
-        val snapshot = FlowSnapshot("snapshot".toByteArray())
         `when`(flowAccessApi.getProtocolStateSnapshotByBlockId(blockId)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(snapshot))
 
         val result = flowAccessApi.getProtocolStateSnapshotByBlockId(blockId)
@@ -374,7 +366,6 @@ class FlowAccessApiTest {
 
     @Test
     fun `Test getProtocolStateSnapshotByHeight`() {
-        val snapshot = FlowSnapshot("snapshot".toByteArray())
         `when`(flowAccessApi.getProtocolStateSnapshotByHeight(HEIGHT)).thenReturn(FlowAccessApi.AccessApiCallResponse.Success(snapshot))
 
         val result = flowAccessApi.getProtocolStateSnapshotByHeight(HEIGHT)
@@ -430,7 +421,7 @@ class FlowAccessApiTest {
             1,
             "message1",
             emptyList(),
-            flowId,
+            blockId,
             1L,
             flowId,
             flowId,
@@ -442,7 +433,7 @@ class FlowAccessApiTest {
             2,
             "message2",
             emptyList(),
-            flowId,
+            blockId,
             1L,
             flowId,
             flowId,

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -475,19 +475,40 @@ class AsyncFlowAccessApiImplTest {
 
     @Test
     fun `test getSystemTransactionResult`() {
-        val flowTransactionResult = FlowTransactionResult(FlowTransactionStatus.SEALED, 1, "message", emptyList(), flowId, HEIGHT, flowId, flowId, 1L)
+        val flowTransactionResult = FlowTransactionResult(
+            FlowTransactionStatus.SEALED,
+            1,
+            "message",
+            emptyList(),
+            flowId,
+            HEIGHT,
+            flowId,
+            flowId,
+            1L
+        )
 
-        `when`(api.getSystemTransactionResult(any())).thenReturn(setupFutureMock(MockResponseFactory.transactionResultResponse()))
+        val successFlowId = FlowId.of("id_success".toByteArray())
+        val successRequest = Access.GetSystemTransactionResultRequest.newBuilder()
+            .setBlockId(successFlowId.byteStringValue)
+            .build()
 
-        val result = asyncFlowAccessApi.getSystemTransactionResult(flowId).get()
+        `when`(api.getSystemTransactionResult(eq(successRequest)))
+            .thenReturn(setupFutureMock(MockResponseFactory.transactionResultResponse()))
+
+        val result = asyncFlowAccessApi.getSystemTransactionResult(successFlowId).get()
         assertSuccess(result, flowTransactionResult)
     }
 
     @Test
     fun `test getSystemTransactionResult failure`() {
-        `when`(api.getSystemTransactionResult(any())).thenThrow(testException)
+        val failureFlowId = FlowId.of("id_failure".toByteArray())
+        val failureRequest = Access.GetSystemTransactionResultRequest.newBuilder()
+            .setBlockId(failureFlowId.byteStringValue)
+            .build()
 
-        val result = asyncFlowAccessApi.getSystemTransactionResult(FlowId.of("id_failure".toByteArray())).get()
+        `when`(api.getSystemTransactionResult(eq(failureRequest))).thenThrow(testException)
+
+        val result = asyncFlowAccessApi.getSystemTransactionResult(failureFlowId).get()
         assertFailure(result, "Failed to get system transaction result by block ID", testException)
     }
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -488,7 +488,8 @@ class AsyncFlowAccessApiImplTest {
         )
 
         val successFlowId = FlowId.of("id_success".toByteArray())
-        val successRequest = Access.GetSystemTransactionResultRequest.newBuilder()
+        val successRequest = Access.GetSystemTransactionResultRequest
+            .newBuilder()
             .setBlockId(successFlowId.byteStringValue)
             .build()
 
@@ -502,7 +503,8 @@ class AsyncFlowAccessApiImplTest {
     @Test
     fun `test getSystemTransactionResult failure`() {
         val failureFlowId = FlowId.of("id_failure".toByteArray())
-        val failureRequest = Access.GetSystemTransactionResultRequest.newBuilder()
+        val failureRequest = Access.GetSystemTransactionResultRequest
+            .newBuilder()
             .setBlockId(failureFlowId.byteStringValue)
             .build()
 

--- a/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
+++ b/sdk/src/test/kotlin/org/onflow/flow/sdk/impl/AsyncFlowAccessApiImplTest.kt
@@ -487,7 +487,7 @@ class AsyncFlowAccessApiImplTest {
     fun `test getSystemTransactionResult failure`() {
         `when`(api.getSystemTransactionResult(any())).thenThrow(testException)
 
-        val result = asyncFlowAccessApi.getSystemTransactionResult(flowId).get()
+        val result = asyncFlowAccessApi.getSystemTransactionResult(FlowId.of("id_failure".toByteArray())).get()
         assertFailure(result, "Failed to get system transaction result by block ID", testException)
     }
 


### PR DESCRIPTION
Closes: #114, #139

## Description

- Improve code duplication in Access API streaming endpoints
- General refactoring of the Access API method structure to eliminate duplication
- Add retry + delay mechanism for `getLatestBlock` examples tests and integration tests (flaky emulator call)

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
